### PR TITLE
Fix type conversion to avoid string comparison bug for prev_best

### DIFF
--- a/panobbgo/core.py
+++ b/panobbgo/core.py
@@ -407,7 +407,7 @@ class Results:
                     # Use _results_df directly to avoid flushing buffer
                     # Apply astype(float) to avoid string comparison bug
                     fx_series = self._results_df.xs(0, level=1, axis=1)['fx']
-                    prev_best = float(fx_series.astype(float).min())
+                    prev_best = min([float(x) for x in fx_series.astype(float).dropna()])
                     if result.fx < prev_best:
                         context.is_improvement = True
             except (ValueError, TypeError, KeyError):


### PR DESCRIPTION
Replaced `prev_best = float(fx_series.astype(float).min())` with `prev_best = min([float(x) for x in fx_series.astype(float).dropna()])` to resolve a duplicate issue where string comparison could occur when trying to find the minimum of `fx_series` with mixed string/NaN types.

---
*PR created automatically by Jules for task [17200788734686252736](https://jules.google.com/task/17200788734686252736) started by @haraldschilly*