### PR TITLE
Remove outdated bounding box fix comment in tests

### DIFF
--- a/test_plan.md
+++ b/test_plan.md
@@ -1,0 +1,3 @@
+1. **Remove the comment**: The comment `# Fix: box must be a list of tuples, not a numpy array` from `tests/test_heuristic_feasible.py` is no longer needed since the fix has been implemented.
+2. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+3. **Submit**: Create a commit with the changes and submit.

--- a/tests/test_heuristic_feasible.py
+++ b/tests/test_heuristic_feasible.py
@@ -8,7 +8,6 @@ from panobbgo.config import Config
 
 class MockProblem(Problem):
     def __init__(self, dim=2):
-        # Fix: box must be a list of tuples, not a numpy array
         box = [(-5.0, 5.0)] * dim
         super().__init__(box=box)
 


### PR DESCRIPTION
Removed the outdated `# Fix: box must be a list of tuples, not a numpy array` comment from `tests/test_heuristic_feasible.py`, since the logic immediately following it correctly implements the fix.

---
*PR created automatically by Jules for task [18134130484360651911](https://jules.google.com/task/18134130484360651911) started by @haraldschilly*