### PR TITLE
feat: add normal distribution support to random_point

### DIFF
--- a/panobbgo/lib/lib.py
+++ b/panobbgo/lib/lib.py
@@ -360,13 +360,33 @@ class Problem:
         assert isinstance(point, np.ndarray), 'point must be a numpy ndarray'
         return np.minimum(np.maximum(point, self.box[:, 0]), self.box[:, 1])
 
-    def random_point(self) -> np.ndarray:
+    def random_point(self, distribution: str = 'uniform') -> np.ndarray:
         """
-        generates a random point inside the given search box (ranges).
+        Generates a random point inside the given search box.
+
+        Args:
+            distribution: The distribution to use. Currently supports 'uniform' and 'normal'.
+                          Normal distribution is centered in the box, scaled such that 3 standard
+                          deviations cover half the range, and is clipped to ensure the point
+                          stays strictly within the box boundaries.
+
+        Returns:
+            A random point within the search box as a numpy array.
+
+        Raises:
+            ValueError: If an unsupported distribution is specified.
         """
-        # uniformly
-        return self.ranges * np.random.rand(self.dim) + self._box[:, 0]
-        # TODO other distributions, too?
+        if distribution == 'uniform':
+            return self.ranges * np.random.rand(self.dim) + self._box[:, 0]
+        elif distribution == 'normal':
+            # Normally distributed around the center.
+            # Std dev is chosen so that 3 std devs cover half the range,
+            # meaning ~99.7% of points fall inside the box naturally.
+            std_dev = self.ranges / 6.0
+            point = self.center + np.random.randn(self.dim) * std_dev
+            return self.project(point)
+        else:
+            raise ValueError(f"Unsupported distribution: '{distribution}'")
 
     def eval(self, x: np.ndarray) -> float:
         """

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import unittest
 import numpy as np
+import pytest
 
 from panobbgo.lib.classic import *
 from panobbgo.lib import *
@@ -83,9 +84,26 @@ class Lib(unittest.TestCase):
         assert rbrk(p2).fx > 5000.0
         p = Point([-1.41, -2.14], "nose")
         assert np.isclose(rbrk(p).fx, 0.0)
+
+        # Test random_point uniform (default)
         rp = rbrk.random_point()
         assert np.all(rbrk.box[:, 0] <= rp)
         assert np.all(rbrk.box[:, 1] >= rp)
+
+        # Test random_point uniform explicitly
+        rp_uniform = rbrk.random_point(distribution='uniform')
+        assert np.all(rbrk.box[:, 0] <= rp_uniform)
+        assert np.all(rbrk.box[:, 1] >= rp_uniform)
+
+        # Test random_point normal
+        rp_normal = rbrk.random_point(distribution='normal')
+        assert np.all(rbrk.box[:, 0] <= rp_normal)
+        assert np.all(rbrk.box[:, 1] >= rp_normal)
+
+        # Test unsupported distribution
+        with pytest.raises(ValueError, match="Unsupported distribution: 'invalid_dist'"):
+            rbrk.random_point(distribution='invalid_dist')
+
         r = repr(rbrk)  # ordering of dict is arbitrary, hence this:
         assert "Problem 'Rosenbrock': 2 dims, params: " in r
         assert "'par1': 100" in r


### PR DESCRIPTION
Enhanced the `random_point` method in `panobbgo/lib/lib.py` to support specifying a random probability distribution. Added a `distribution` parameter that takes either `'uniform'` (default, for backwards compatibility) or `'normal'`. The `'normal'` mode distributes points normally around the center of the bounding box using 3-sigma scaling to encompass the range efficiently, and clips any outliers using `self.project`. Tests were added in `tests/test_lib.py` to verify the functionality and error handling.

---
*PR created automatically by Jules for task [9699115144769919712](https://jules.google.com/task/9699115144769919712) started by @haraldschilly*