### PR TITLE
fix: ensure arrays for indexing safety in GP scalar prediction

### DIFF
--- a/panobbgo/heuristics/gaussian_process.py
+++ b/panobbgo/heuristics/gaussian_process.py
@@ -459,6 +459,8 @@ class GaussianProcessHeuristic(Heuristic):
         EI(x) = (μ(x) - f*) * Φ(Z) + σ(x) * φ(Z)
         where Z = (μ(x) - f*) / σ(x)
         """
+        y_pred = np.atleast_1d(y_pred)
+        y_std = np.atleast_1d(y_std)
         with np.errstate(divide="ignore", invalid="ignore"):
             z = (self.best_y - y_pred) / y_std
             ei = (self.best_y - y_pred) * self._norm_cdf(z) + y_std * self._norm_pdf(z)
@@ -481,6 +483,8 @@ class GaussianProcessHeuristic(Heuristic):
 
         PI(x) = Φ((f* - μ(x)) / σ(x))
         """
+        y_pred = np.atleast_1d(y_pred)
+        y_std = np.atleast_1d(y_std)
         with np.errstate(divide="ignore", invalid="ignore"):
             z = (self.best_y - y_pred) / y_std
             pi = self._norm_cdf(z)


### PR DESCRIPTION
This resolves an issue where scalar predictions from the underlying GP model could cause indexing errors when attempting to handle zero variance cases.

Added `np.atleast_1d` calls for `y_pred` and `y_std` in:
- `_expected_improvement`
- `_probability_of_improvement`

This ensures `ei[y_std == 0] = 0.0` and `pi[y_std == 0] = 0.0` execute safely regardless of whether the prediction returns a scalar or array.

---
*PR created automatically by Jules for task [6080245334033424227](https://jules.google.com/task/6080245334033424227) started by @haraldschilly*