### PR TITLE
Add CMA-ES heuristic — gold standard for continuous black-box optimization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,33 @@
 
 ## Recent Improvements
 
+### CMA-ES Heuristic & Core Reward Fix (2026-04-18)
+- [x] **Implemented `CMAES` heuristic** (`panobbgo/heuristics/cma_es.py`)
+  - Pure-NumPy implementation of the canonical CMA-ES algorithm (Hansen 2016)
+  - Async-compatible: tracks results per generation via `who = "CMAES:g<gen>:i<idx>"` tags
+  - Adapts covariance matrix C and step size σ from evaluated offspring
+  - Lazy eigendecomposition with condition-number guard (resets to spherical if > 1e7)
+  - Parameters: `sigma0` (initial step-size fraction), `popsize` (overrides λ=4+3 ln n),
+    `min_results_fraction` (fraction of λ before update trigger, default 0.5 = μ)
+  - Gold standard for smooth/ridge-following problems (Rosenbrock, ill-conditioned quadratics)
+- [x] **Added `CMAES` to standard and full harness strategies** (`panobbgo/harness.py`)
+  - `CMAES_Portfolio` strategy in standard mode: LatinHypercube + CMAES + Nearby + NelderMead
+  - `CMAES_GP` strategy in full mode: LatinHypercube + CMAES + GaussianProcessHeuristic + NelderMead
+  - Intentionally excluded from quick mode (75 evals) — CMA-ES needs ≥ 100 evals to converge
+- [x] **Fixed `StrategyBase.heuristic()` lookup for compound `who` strings** (`panobbgo/core.py`)
+  - Heuristics like CMAES and DifferentialEvolution embed generation/UUID info in `who`
+    (e.g., `"CMAES:g3:i0"`, `"DifferentialEvolution:abc123"`)
+  - `heuristic(who)` now falls back to the prefix before `:` if the full key is not found
+  - Prevents spurious `KeyError` in `StrategyRewarding.on_new_best` and `_reward_near_best`
+- [x] **20 comprehensive tests** (`tests/test_heuristic_cmaes.py`)
+  - Initialisation, parameter validation, point emission within bounds
+  - Update triggering from partial results, mean convergence, sigma adaptation
+  - Covariance positive-definiteness, weight normalisation, foreign-result handling
+  - End-to-end integration test on Rosenbrock 2D (150 evals, fx < 5.0)
+- [x] **Documentation updated**
+  - `doc/source/guide_architecture.rst`: CMAES added to "Population-based" heuristics section
+  - `doc/source/guide_usage.rst`: Added CMA-ES portfolio table entry and usage example
+
 ### Bayesian Optimization Harness Integration & UCB Bug Fix (2026-04-17)
 - [x] **BayesOpt_GP strategy added to standard harness** (`panobbgo/harness.py`)
   - New `BayesOpt_GP` strategy spec added to `_make_standard_strategies()` (200-eval budget)

--- a/doc/source/guide_architecture.rst
+++ b/doc/source/guide_architecture.rst
@@ -226,6 +226,14 @@ Implemented Heuristics
 
 **Population-based (global search):**
 
+- :class:`~panobbgo.heuristics.cma_es.CMAES`: Covariance Matrix Adaptation Evolution Strategy.
+  The gold standard for derivative-free optimization of continuous functions.  Maintains a
+  multivariate Gaussian search distribution N(m, σ²C) and adapts both the step size σ and
+  covariance matrix C online.  Invariant under order-preserving objective transformations and
+  orthogonal search-space transformations; excels on ill-conditioned and ridge-following problems
+  such as Rosenbrock.  Implemented in pure NumPy with asynchronous generation tracking that
+  is compatible with panobbgo's threaded evaluation model.
+
 - :class:`~panobbgo.heuristics.differential_evolution.DifferentialEvolution`: Differential Evolution
   mutation/crossover/selection operators run against the accumulated result database.  Excels on
   multimodal landscapes such as Rastrigin and Schwefel where purely local methods get trapped.

--- a/doc/source/guide_usage.rst
+++ b/doc/source/guide_usage.rst
@@ -470,8 +470,8 @@ A good portfolio balances exploration and exploitation:
      - ClaudeHeuristic
      - Multimodal landscapes, finding hidden optima near good regions
    * - Population-based
-     - DifferentialEvolution
-     - Multimodal problems (Rastrigin, Schwefel); no surrogate model needed
+     - CMAES, DifferentialEvolution
+     - CMAES: smooth problems, ridges, and ill-conditioned landscapes (Rosenbrock); DE: multimodal (Rastrigin, Schwefel)
    * - Gradient-free local
      - LBFGSB, LocalPenaltySearch
      - When local structure suspected
@@ -529,6 +529,23 @@ objective; Expected Improvement (EI) acquisition balances exploration and exploi
    strategy.add(Random)
    strategy.add(NelderMead)
    strategy.add(LBFGSB)
+
+**Smooth/ill-conditioned problems with CMA-ES (≥ 100 evals recommended):**
+
+CMA-ES is the gold standard for derivative-free optimization of continuous functions.
+It adapts both step size and covariance to the local geometry, making it exceptionally
+effective on problems with elongated valleys (Rosenbrock), ill-conditioned quadratics,
+or rotated search spaces.
+
+.. code-block:: python
+
+   from panobbgo.heuristics import CMAES, LatinHypercube, NelderMead, Nearby
+
+   strategy = StrategyRewarding(problem, max_evaluations=200)
+   strategy.add(LatinHypercube, div=4)  # Spread initial samples evenly
+   strategy.add(CMAES, sigma0=0.3)      # Self-adapting covariance-matrix search
+   strategy.add(Nearby, radius=0.05)    # Fine local refinement
+   strategy.add(NelderMead)             # Gradient-free simplex local optimizer
 
 **Multimodal problems (Rastrigin, Schwefel):**
 

--- a/panobbgo/core.py
+++ b/panobbgo/core.py
@@ -1168,7 +1168,19 @@ class StrategyBase:
         return list(self._analyzers.values())
 
     def heuristic(self, who):
-        return self._heuristics[who]
+        """Look up a heuristic by its *who* tag.
+
+        Some heuristics (e.g. :class:`~panobbgo.heuristics.CMAES`,
+        :class:`~panobbgo.heuristics.DifferentialEvolution`) embed extra
+        context in the ``who`` field (e.g. ``"CMAES:g3:i0"``).  We first try
+        the full string, then fall back to the prefix before the first ``:``.
+        """
+        if who in self._heuristics:
+            return self._heuristics[who]
+        base = who.split(":")[0]
+        if base in self._heuristics:
+            return self._heuristics[base]
+        raise KeyError(who)
 
     def analyzer(self, who):
         return self._analyzers[who]

--- a/panobbgo/harness.py
+++ b/panobbgo/harness.py
@@ -224,6 +224,11 @@ def _make_quick_strategies() -> List[StrategySpec]:
     analyzer so that the sensitivity-aware :class:`~panobbgo.heuristics.nearby.Nearby`
     heuristic can scale perturbations by dimension importance once enough evaluations
     have been accumulated.
+
+    CMA-ES is intentionally excluded from the quick strategy: with only 75 evaluations
+    its covariance adaptation has too little data to converge, and the population overhead
+    dilutes the budget for the faster local heuristics.  Use ``CMAES_Portfolio`` in
+    standard or full mode for CMA-ES benchmarking.
     """
     from panobbgo.strategies import StrategyRoundRobin, StrategyRewarding
     from panobbgo.heuristics import Random, Nearby, NelderMead, Center
@@ -250,11 +255,15 @@ def _make_quick_strategies() -> List[StrategySpec]:
 
 
 def _make_standard_strategies() -> List[StrategySpec]:
-    """Four strategies: baseline, adaptive, bandit, Bayesian GP.
+    """Five strategies: baseline, adaptive (with CMA-ES), UCB bandit, Bayesian GP, CMA-ES portfolio.
 
     BayesOpt_GP uses a Gaussian Process surrogate (Expected Improvement acquisition)
     paired with LatinHypercube initialization.  With 200 evaluations the GP model
     has enough data to build an accurate surrogate and guide search efficiently.
+
+    CMAES_Portfolio pairs CMA-ES with LatinHypercube initialization and NelderMead
+    local refinement inside a Rewarding strategy.  CMA-ES adapts its covariance
+    matrix to the local geometry, providing strong performance on smooth functions.
     """
     from panobbgo.strategies import StrategyUCB, StrategyRewarding
     from panobbgo.heuristics import (
@@ -263,6 +272,7 @@ def _make_standard_strategies() -> List[StrategySpec]:
         NelderMead,
         LatinHypercube,
         GaussianProcessHeuristic,
+        CMAES,
     )
     from panobbgo.analyzers import Sensitivity
 
@@ -289,15 +299,30 @@ def _make_standard_strategies() -> List[StrategySpec]:
         ],
         analyzers=[(Sensitivity, {"update_interval": 20})],
     )
-    return quick + [ucb, bayes_gp]
+    cmaes_portfolio = StrategySpec(
+        name="CMAES_Portfolio",
+        strategy_class=StrategyRewarding,
+        heuristics=[
+            (LatinHypercube, {"div": 4}),
+            (CMAES, {"sigma0": 0.3}),
+            (Nearby, {"radius": 0.05, "axes": "all", "new": 3}),
+            (NelderMead, {}),
+        ],
+        analyzers=[(Sensitivity, {"update_interval": 20})],
+    )
+    return quick + [ucb, bayes_gp, cmaes_portfolio]
 
 
 def _make_full_strategies() -> List[StrategySpec]:
-    """Full strategy set including Thompson Sampling and enhanced Bayesian GP.
+    """Full strategy set including Thompson Sampling, enhanced Bayesian GP, and CMA-ES+GP.
 
     BayesOpt_Enhanced pairs GP (EI acquisition, 10 restarts) with DifferentialEvolution
     for global exploration and NelderMead for local refinement.  The larger 500-evaluation
     budget lets the GP build a highly accurate surrogate model.
+
+    CMAES_GP combines CMA-ES with the Gaussian Process heuristic inside a Rewarding
+    strategy.  CMA-ES provides efficient local adaptation while GP suggests globally
+    promising regions, and the bandit allocates budget according to performance.
     """
     from panobbgo.strategies import StrategyThompsonSampling, StrategyRewarding
     from panobbgo.heuristics import (
@@ -307,6 +332,7 @@ def _make_full_strategies() -> List[StrategySpec]:
         LatinHypercube,
         GaussianProcessHeuristic,
         DifferentialEvolution,
+        CMAES,
     )
     from panobbgo.analyzers import Sensitivity
 
@@ -333,7 +359,18 @@ def _make_full_strategies() -> List[StrategySpec]:
         ],
         analyzers=[(Sensitivity, {"update_interval": 20})],
     )
-    return base + [thompson, bayes_enhanced]
+    cmaes_gp = StrategySpec(
+        name="CMAES_GP",
+        strategy_class=StrategyRewarding,
+        heuristics=[
+            (LatinHypercube, {"div": 4}),
+            (CMAES, {"sigma0": 0.3}),
+            (GaussianProcessHeuristic, {"n_restarts": 5}),
+            (NelderMead, {}),
+        ],
+        analyzers=[(Sensitivity, {"update_interval": 20})],
+    )
+    return base + [thompson, bayes_enhanced, cmaes_gp]
 
 
 # ---------------------------------------------------------------------------

--- a/panobbgo/heuristics/__init__.py
+++ b/panobbgo/heuristics/__init__.py
@@ -41,6 +41,7 @@ from .local_penalty_search import LocalPenaltySearch
 from .claude_heuristic import ClaudeHeuristic
 from .differential_evolution import DifferentialEvolution
 from .repair import ConstraintRepair
+from .cma_es import CMAES
 
 __all__ = [
     "Center",
@@ -60,4 +61,5 @@ __all__ = [
     "ClaudeHeuristic",
     "DifferentialEvolution",
     "ConstraintRepair",
+    "CMAES",
 ]

--- a/panobbgo/heuristics/cma_es.py
+++ b/panobbgo/heuristics/cma_es.py
@@ -1,0 +1,389 @@
+# -*- coding: utf8 -*-
+# Copyright 2012-2026 Harald Schilly <harald.schilly@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CMA-ES Heuristic
+================
+
+Covariance Matrix Adaptation Evolution Strategy (CMA-ES).
+
+CMA-ES is the gold-standard algorithm for derivative-free optimization of
+continuous, possibly multimodal functions.  It maintains a multivariate
+Gaussian search distribution N(m, σ²C) and adapts both the step-size σ
+and the full covariance matrix C from the history of successful steps.
+
+Key strengths:
+- Invariant under order-preserving transformations of the objective
+- Invariant under orthogonal transformations of the search space
+- Excellent at following narrow ridges / valleys (e.g. Rosenbrock)
+- Self-adaptive: no manual step-size tuning required
+
+This implementation follows the canonical description in:
+  N. Hansen (2016). "The CMA Evolution Strategy: A Tutorial."
+  arXiv:1604.00772.
+
+The heuristic works asynchronously inside the panobbgo event loop:
+
+1. ``on_start()``  — initialise parameters and emit the first generation of λ candidates.
+2. ``on_new_results()``  — collect returned results tagged with our generation ID.
+   When at least μ results from the oldest open generation have arrived, perform
+   one CMA-ES update step and emit the next generation.
+
+.. codeauthor:: Harald Schilly
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from panobbgo.core import Heuristic
+from panobbgo.lib import Point
+
+
+class CMAES(Heuristic):
+    """Covariance Matrix Adaptation Evolution Strategy heuristic.
+
+    Maintains a multivariate Gaussian search distribution N(m, σ²C) and
+    adapts it from the history of evaluated points.  Particularly effective
+    for functions with elongated or ill-conditioned level sets (e.g. Rosenbrock).
+
+    Args:
+        strategy: The optimization strategy instance.
+        sigma0 (float, optional): Initial step size as a fraction of the mean
+            box half-range.  Defaults to 0.3 (30 % of the search space).
+        popsize (int, optional): Override the default population size
+            ``λ = 4 + floor(3·ln n)``.  Useful for low-budget runs.
+        min_results_fraction (float): Fraction of λ that must arrive before
+            a CMA-ES update is triggered.  Default 0.5 (= μ).
+    """
+
+    def __init__(
+        self,
+        strategy,
+        sigma0: float = 0.3,
+        popsize: Optional[int] = None,
+        min_results_fraction: float = 0.5,
+    ):
+        super().__init__(strategy, name="CMAES")
+        self.logger = self.config.get_logger("H:CMA")
+        self._sigma0_frac = sigma0
+        self._popsize_override = popsize
+        self._min_results_fraction = min_results_fraction
+
+        # CMA-ES algorithm state (set in on_start)
+        self._m: Optional[np.ndarray] = None
+        self._sigma: float = 1.0
+        self._C: Optional[np.ndarray] = None
+        self._p_c: Optional[np.ndarray] = None
+        self._p_sigma: Optional[np.ndarray] = None
+        self._B: Optional[np.ndarray] = None
+        self._D: Optional[np.ndarray] = None
+        self._eigeneval: int = 0
+        self._counteval: int = 0
+
+        # Strategy parameters (set in on_start)
+        self._lam: int = 0
+        self._mu: int = 0
+        self._w: Optional[np.ndarray] = None
+        self._mu_eff: float = 1.0
+        self._c_sigma: float = 0.0
+        self._d_sigma: float = 1.0
+        self._c_c: float = 0.0
+        self._c_1: float = 0.0
+        self._c_mu: float = 0.0
+        self._chi_n: float = 1.0
+
+        # Generation tracking for async operation
+        self._gen: int = 0
+        self._pending: Dict[str, dict] = {}
+        self._gen_results: Dict[int, List[dict]] = {}
+
+        # Box bounds (set in on_start)
+        self._lo: Optional[np.ndarray] = None
+        self._hi: Optional[np.ndarray] = None
+        self._ranges: Optional[np.ndarray] = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def on_start(self) -> None:
+        """Initialise CMA-ES state and emit the first generation."""
+        n = self.problem.dim
+
+        # Population sizes
+        lam = self._popsize_override or (4 + int(3 * np.log(max(n, 2))))
+        mu = lam // 2
+
+        # Recombination weights (log-linear, positive)
+        raw_w = np.log(mu + 0.5) - np.log(np.arange(1, mu + 1, dtype=float))
+        w = raw_w / raw_w.sum()
+
+        # Effective number of parents
+        mu_eff = 1.0 / (w**2).sum()
+
+        # Step-size control
+        c_sigma = (mu_eff + 2.0) / (n + mu_eff + 5.0)
+        d_sigma = (
+            1.0
+            + 2.0 * max(0.0, np.sqrt((mu_eff - 1.0) / (n + 1.0)) - 1.0)
+            + c_sigma
+        )
+
+        # Covariance matrix control
+        c_c = (4.0 + mu_eff / n) / (n + 4.0 + 2.0 * mu_eff / n)
+        c_1 = 2.0 / ((n + 1.3) ** 2 + mu_eff)
+        c_mu = min(
+            1.0 - c_1,
+            2.0 * (mu_eff - 2.0 + 1.0 / mu_eff) / ((n + 2.0) ** 2 + mu_eff),
+        )
+
+        # Expected norm of N(0,I)
+        chi_n = np.sqrt(n) * (1.0 - 1.0 / (4.0 * n) + 1.0 / (21.0 * n**2))
+
+        # Search-space bounds
+        box = self.problem.box.box
+        lo = box[:, 0]
+        hi = box[:, 1]
+        ranges = hi - lo
+
+        # Initial mean: box centre
+        m = 0.5 * (lo + hi)
+
+        # Initial step size: fraction of mean box half-range
+        sigma = self._sigma0_frac * float(np.mean(ranges) / 2.0)
+        sigma = max(sigma, 1e-6)
+
+        # Persist
+        self._lam = lam
+        self._mu = mu
+        self._w = w
+        self._mu_eff = mu_eff
+        self._c_sigma = c_sigma
+        self._d_sigma = d_sigma
+        self._c_c = c_c
+        self._c_1 = c_1
+        self._c_mu = c_mu
+        self._chi_n = chi_n
+
+        self._lo = lo
+        self._hi = hi
+        self._ranges = ranges
+
+        self._m = m
+        self._sigma = sigma
+        self._C = np.eye(n)
+        self._p_c = np.zeros(n)
+        self._p_sigma = np.zeros(n)
+        self._B = np.eye(n)
+        self._D = np.ones(n)
+        self._eigeneval = 0
+        self._counteval = 0
+
+        self._gen = 0
+        self._pending = {}
+        self._gen_results = {}
+
+        self.logger.info(
+            "CMA-ES started: n=%d λ=%d μ=%d σ0=%.4f", n, lam, mu, sigma
+        )
+        self._emit_generation()
+
+    # ------------------------------------------------------------------
+    # Event handler
+    # ------------------------------------------------------------------
+
+    def on_new_results(self, results) -> None:
+        """Collect results and trigger a CMA-ES update when enough have arrived."""
+        for r in results:
+            if not r.who.startswith("CMAES:"):
+                continue
+            if r.fx is None or not np.isfinite(r.fx):
+                continue
+
+            info = self._pending.pop(r.who, None)
+            if info is None:
+                continue
+
+            gen = info["gen"]
+            gen_bucket = self._gen_results.get(gen)
+            if gen_bucket is None:
+                continue
+
+            penalty = self.strategy.constraint_handler.get_penalty_value(r)
+            gen_bucket.append(
+                {
+                    "penalty": penalty,
+                    "x": r.x.copy(),
+                    "y": info["y"],
+                }
+            )
+
+        # Check if we can perform an update for the oldest open generation.
+        min_needed = max(2, int(self._lam * self._min_results_fraction))
+        for gen in sorted(self._gen_results.keys()):
+            bucket = self._gen_results[gen]
+            if len(bucket) >= min_needed:
+                self._update(bucket)
+                del self._gen_results[gen]
+                self._emit_generation()
+                break
+
+    # ------------------------------------------------------------------
+    # Core CMA-ES update
+    # ------------------------------------------------------------------
+
+    def _emit_generation(self) -> None:
+        """Sample λ candidates from N(m, σ²C) and emit them."""
+        if self._m is None or self._B is None or self._D is None:
+            return
+
+        n = self.problem.dim
+        self._gen += 1
+        gen = self._gen
+        self._gen_results[gen] = []
+
+        for i in range(self._lam):
+            z = np.random.randn(n)
+            # y = B D z  →  covariance = B D² Bᵀ = C
+            y = self._B @ (self._D * z)
+            x = self._m + self._sigma * y
+            x = self.problem.project(x)
+
+            who = f"CMAES:g{gen}:i{i}"
+            self._pending[who] = {"gen": gen, "i": i, "y": y}
+            # Put directly to bypass emit()'s ndarray-only check,
+            # preserving the custom 'who' tag needed for generation tracking.
+            try:
+                self._output.put_nowait(Point(x, who))
+            except Exception:
+                pass
+
+    def _update(self, collected: List[dict]) -> None:
+        """Perform one CMA-ES parameter update from a set of evaluated offspring."""
+        assert self._m is not None
+        assert self._C is not None
+        assert self._p_c is not None
+        assert self._p_sigma is not None
+        assert self._B is not None
+        assert self._D is not None
+        assert self._w is not None
+
+        n = self.problem.dim
+
+        # Sort by penalty (ascending = minimise)
+        collected.sort(key=lambda d: d["penalty"])
+        selected = collected[: self._mu]
+
+        # Recombination weights (may use fewer than μ if fewer arrived)
+        actual_mu = len(selected)
+        if actual_mu < len(self._w):
+            # Re-normalise weights for the actual number of survivors
+            raw = np.log(actual_mu + 0.5) - np.log(
+                np.arange(1, actual_mu + 1, dtype=float)
+            )
+            w = raw / raw.sum()
+            mu_eff = 1.0 / (w**2).sum()
+        else:
+            w = self._w
+            mu_eff = self._mu_eff
+
+        # --- Mean update ---
+        self._m = sum(w[i] * d["x"] for i, d in enumerate(selected))  # type: ignore[assignment]
+
+        # Step in normalised y-space (weighted recombination)
+        y_w = sum(w[i] * d["y"] for i, d in enumerate(selected))
+
+        # --- Step-size path update ---
+        # C^{-1/2} y_w  =  B diag(1/D) Bᵀ y_w
+        C_invsqrt_yw = self._B @ ((1.0 / self._D) * (self._B.T @ y_w))
+
+        self._p_sigma = (1.0 - self._c_sigma) * self._p_sigma + np.sqrt(
+            self._c_sigma * (2.0 - self._c_sigma) * mu_eff
+        ) * C_invsqrt_yw
+
+        # Stall indicator: is p_sigma still growing?
+        norm_p_sigma = float(np.linalg.norm(self._p_sigma))
+        gen_count = self._counteval / self._lam + 1.0
+        expected = np.sqrt(1.0 - (1.0 - self._c_sigma) ** (2.0 * gen_count))
+        h_sigma = norm_p_sigma / (expected * self._chi_n) < 1.4 + 2.0 / (n + 1.0)
+
+        # --- Covariance path update ---
+        self._p_c = (1.0 - self._c_c) * self._p_c + h_sigma * np.sqrt(
+            self._c_c * (2.0 - self._c_c) * mu_eff
+        ) * y_w
+
+        # --- Covariance matrix update ---
+        # Rank-μ term
+        Y = np.column_stack([d["y"] for d in selected])  # (n, actual_mu)
+        rank_mu = (Y * w[:actual_mu]) @ Y.T  # weighted outer-product sum
+
+        # Correction for h_sigma = 0
+        delta_h = (1.0 - h_sigma) * self._c_c * (2.0 - self._c_c)
+
+        self._C = (
+            (1.0 - self._c_1 - self._c_mu) * self._C
+            + self._c_1
+            * (np.outer(self._p_c, self._p_c) + delta_h * self._C)
+            + self._c_mu * rank_mu
+        )
+
+        # --- Step-size update (cumulative path length control) ---
+        self._sigma *= float(
+            np.exp(
+                (self._c_sigma / self._d_sigma)
+                * (norm_p_sigma / self._chi_n - 1.0)
+            )
+        )
+
+        # Clamp step size
+        max_sigma = float(np.mean(self._ranges))
+        self._sigma = float(np.clip(self._sigma, 1e-12, max_sigma))
+
+        self._counteval += actual_mu
+
+        # --- Lazy eigendecomposition ---
+        # Update frequency: every lam / (c_1 + c_mu) / n / 10 evaluations
+        update_gap = max(1, int(self._lam / (self._c_1 + self._c_mu) / n / 10))
+        if self._counteval - self._eigeneval >= update_gap:
+            self._eigeneval = self._counteval
+            # Enforce symmetry, then decompose
+            C_sym = (self._C + self._C.T) / 2.0
+            try:
+                eigvals, self._B = np.linalg.eigh(C_sym)
+            except np.linalg.LinAlgError:
+                self.logger.warning("CMA-ES: eigendecomposition failed — resetting C")
+                self._reset_covariance(n)
+                return
+
+            # Clamp eigenvalues (avoid collapse or explosion)
+            eigvals = np.maximum(eigvals, 1e-20)
+            self._D = np.sqrt(eigvals)
+            self._C = C_sym
+
+            # Condition-number guard
+            if self._D.max() / self._D.min() > 1e7:
+                self.logger.info("CMA-ES: condition number too large — resetting C")
+                self._reset_covariance(n)
+
+    def _reset_covariance(self, n: int) -> None:
+        """Reset covariance to identity (recover from ill-conditioning)."""
+        self._C = np.eye(n)
+        self._p_c = np.zeros(n)
+        self._p_sigma = np.zeros(n)
+        self._B = np.eye(n)
+        self._D = np.ones(n)

--- a/panobbgo/heuristics/cma_es.py
+++ b/panobbgo/heuristics/cma_es.py
@@ -282,6 +282,16 @@ class CMAES(Heuristic):
         assert self._B is not None
         assert self._D is not None
         assert self._w is not None
+        assert self._ranges is not None
+
+        # Local non-None aliases (avoid repeated attribute-narrowing loss).
+        C = self._C
+        p_c = self._p_c
+        p_sigma = self._p_sigma
+        B = self._B
+        D = self._D
+        w_full = self._w
+        ranges = self._ranges
 
         n = self.problem.dim
 
@@ -291,7 +301,7 @@ class CMAES(Heuristic):
 
         # Recombination weights (may use fewer than μ if fewer arrived)
         actual_mu = len(selected)
-        if actual_mu < len(self._w):
+        if actual_mu < len(w_full):
             # Re-normalise weights for the actual number of survivors
             raw = np.log(actual_mu + 0.5) - np.log(
                 np.arange(1, actual_mu + 1, dtype=float)
@@ -299,7 +309,7 @@ class CMAES(Heuristic):
             w = raw / raw.sum()
             mu_eff = 1.0 / (w**2).sum()
         else:
-            w = self._w
+            w = w_full
             mu_eff = self._mu_eff
 
         # --- Mean update ---
@@ -310,20 +320,20 @@ class CMAES(Heuristic):
 
         # --- Step-size path update ---
         # C^{-1/2} y_w  =  B diag(1/D) Bᵀ y_w
-        C_invsqrt_yw = self._B @ ((1.0 / self._D) * (self._B.T @ y_w))
+        C_invsqrt_yw = B @ ((1.0 / D) * (B.T @ y_w))
 
-        self._p_sigma = (1.0 - self._c_sigma) * self._p_sigma + np.sqrt(
+        p_sigma = (1.0 - self._c_sigma) * p_sigma + np.sqrt(
             self._c_sigma * (2.0 - self._c_sigma) * mu_eff
         ) * C_invsqrt_yw
 
         # Stall indicator: is p_sigma still growing?
-        norm_p_sigma = float(np.linalg.norm(self._p_sigma))
+        norm_p_sigma = float(np.linalg.norm(p_sigma))
         gen_count = self._counteval / self._lam + 1.0
         expected = np.sqrt(1.0 - (1.0 - self._c_sigma) ** (2.0 * gen_count))
         h_sigma = norm_p_sigma / (expected * self._chi_n) < 1.4 + 2.0 / (n + 1.0)
 
         # --- Covariance path update ---
-        self._p_c = (1.0 - self._c_c) * self._p_c + h_sigma * np.sqrt(
+        p_c = (1.0 - self._c_c) * p_c + h_sigma * np.sqrt(
             self._c_c * (2.0 - self._c_c) * mu_eff
         ) * y_w
 
@@ -335,10 +345,9 @@ class CMAES(Heuristic):
         # Correction for h_sigma = 0
         delta_h = (1.0 - h_sigma) * self._c_c * (2.0 - self._c_c)
 
-        self._C = (
-            (1.0 - self._c_1 - self._c_mu) * self._C
-            + self._c_1
-            * (np.outer(self._p_c, self._p_c) + delta_h * self._C)
+        C = (
+            (1.0 - self._c_1 - self._c_mu) * C
+            + self._c_1 * (np.outer(p_c, p_c) + delta_h * C)
             + self._c_mu * rank_mu
         )
 
@@ -351,10 +360,15 @@ class CMAES(Heuristic):
         )
 
         # Clamp step size
-        max_sigma = float(np.mean(self._ranges))
+        max_sigma = float(np.mean(ranges))
         self._sigma = float(np.clip(self._sigma, 1e-12, max_sigma))
 
         self._counteval += actual_mu
+
+        # Persist path/covariance state back to instance.
+        self._p_c = p_c
+        self._p_sigma = p_sigma
+        self._C = C
 
         # --- Lazy eigendecomposition ---
         # Update frequency: every lam / (c_1 + c_mu) / n / 10 evaluations
@@ -362,9 +376,9 @@ class CMAES(Heuristic):
         if self._counteval - self._eigeneval >= update_gap:
             self._eigeneval = self._counteval
             # Enforce symmetry, then decompose
-            C_sym = (self._C + self._C.T) / 2.0
+            C_sym = (C + C.T) / 2.0
             try:
-                eigvals, self._B = np.linalg.eigh(C_sym)
+                eigvals, B_new = np.linalg.eigh(C_sym)
             except np.linalg.LinAlgError:
                 self.logger.warning("CMA-ES: eigendecomposition failed — resetting C")
                 self._reset_covariance(n)
@@ -372,11 +386,13 @@ class CMAES(Heuristic):
 
             # Clamp eigenvalues (avoid collapse or explosion)
             eigvals = np.maximum(eigvals, 1e-20)
-            self._D = np.sqrt(eigvals)
+            D_new = np.sqrt(eigvals)
+            self._B = B_new
+            self._D = D_new
             self._C = C_sym
 
             # Condition-number guard
-            if self._D.max() / self._D.min() > 1e7:
+            if D_new.max() / D_new.min() > 1e7:
                 self.logger.info("CMA-ES: condition number too large — resetting C")
                 self._reset_covariance(n)
 

--- a/tests/test_heuristic_cmaes.py
+++ b/tests/test_heuristic_cmaes.py
@@ -1,0 +1,347 @@
+# -*- coding: utf8 -*-
+# Copyright 2012-2026 Harald Schilly <harald.schilly@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the CMA-ES heuristic."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from panobbgo.utils import PanobbgoTestCase
+from panobbgo.lib import Point, Result
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_result(x: np.ndarray, fx: float, who: str = "test") -> Result:
+    """Create a Result for testing."""
+    return Result(Point(x, who), fx)
+
+
+# ---------------------------------------------------------------------------
+# Test class using the PanobbgoTestCase infrastructure
+# ---------------------------------------------------------------------------
+
+
+class TestCMAES(PanobbgoTestCase):
+    def setUp(self):
+        super().setUp()
+        from panobbgo.lib.constraints import DefaultConstraintHandler
+
+        self.strategy.constraint_handler = DefaultConstraintHandler(self.strategy)
+
+    # --- Instantiation and initialisation ---
+
+    def test_import(self):
+        from panobbgo.heuristics import CMAES
+
+        cma = CMAES(self.strategy)
+        assert cma is not None
+
+    def test_on_start_sets_state(self):
+        from panobbgo.heuristics import CMAES
+
+        cma = CMAES(self.strategy)
+        cma.on_start()
+
+        n = self.problem.dim  # Rosenbrock 2D
+        assert cma._m is not None
+        assert cma._m.shape == (n,)
+        assert cma._C is not None
+        assert cma._C.shape == (n, n)
+        assert np.allclose(cma._C, np.eye(n))
+        assert cma._sigma > 0
+        assert cma._lam >= 4
+        assert cma._mu == cma._lam // 2
+        assert cma._w is not None
+        assert len(cma._w) == cma._mu
+        assert np.isclose(cma._w.sum(), 1.0)
+
+    def test_default_popsize(self):
+        from panobbgo.heuristics import CMAES
+
+        for dim in [2, 5, 10]:
+            from panobbgo.lib.classic import Rosenbrock
+
+            self.problem = Rosenbrock(dim)
+            self.strategy = self.init_strategy()
+            from panobbgo.lib.constraints import DefaultConstraintHandler
+
+            self.strategy.constraint_handler = DefaultConstraintHandler(self.strategy)
+            cma = CMAES(self.strategy)
+            cma.on_start()
+            expected_lam = 4 + int(3 * np.log(max(dim, 2)))
+            assert cma._lam == expected_lam
+
+    def test_custom_popsize(self):
+        from panobbgo.heuristics import CMAES
+
+        cma = CMAES(self.strategy, popsize=10)
+        cma.on_start()
+        assert cma._lam == 10
+        assert cma._mu == 5
+
+    def test_mean_initialised_at_box_centre(self):
+        from panobbgo.heuristics import CMAES
+
+        cma = CMAES(self.strategy)
+        cma.on_start()
+        box = self.problem.box.box
+        expected_centre = 0.5 * (box[:, 0] + box[:, 1])
+        assert np.allclose(cma._m, expected_centre)
+
+    # --- Point emission ---
+
+    def test_emits_lam_points_on_start(self):
+        from panobbgo.heuristics import CMAES
+
+        cma = CMAES(self.strategy)
+        cma.on_start()
+        points = cma.get_points(100)
+        assert len(points) == cma._lam
+        assert all(isinstance(p, Point) for p in points)
+
+    def test_emitted_points_within_box(self):
+        from panobbgo.heuristics import CMAES
+
+        cma = CMAES(self.strategy)
+        cma.on_start()
+        points = cma.get_points(100)
+        box = self.problem.box.box
+        for p in points:
+            in_box = np.all(p.x >= box[:, 0]) and np.all(p.x <= box[:, 1])
+            assert in_box, f"Point {p.x} outside box {box}"
+
+    def test_who_tags_contain_generation_info(self):
+        from panobbgo.heuristics import CMAES
+
+        cma = CMAES(self.strategy)
+        cma.on_start()
+        points = cma.get_points(100)
+        for p in points:
+            assert p.who.startswith("CMAES:g"), f"Unexpected who: {p.who}"
+
+    # --- Result collection and update ---
+
+    def _run_one_generation(self, cma, fx_offset: float = 0.0):
+        """Drain the output queue, fake all results, and feed them back."""
+        points = cma.get_points(100)
+        results = []
+        for p in points:
+            fx = np.sum(p.x**2) + fx_offset
+            r = Result(p, fx)
+            results.append(r)
+        cma.on_new_results(results)
+        return results
+
+    def test_update_triggers_new_emission(self):
+        from panobbgo.heuristics import CMAES
+
+        cma = CMAES(self.strategy)
+        cma.on_start()
+        # Drain initial gen-1 points
+        pts_gen1 = cma.get_points(100)
+        assert len(pts_gen1) == cma._lam
+
+        # Feed results for gen 1 → triggers update + gen-2 emission
+        results = [Result(p, float(np.sum(p.x**2))) for p in pts_gen1]
+        cma.on_new_results(results)
+
+        # A new generation should have been emitted
+        pts_gen2 = cma.get_points(100)
+        assert len(pts_gen2) == cma._lam
+
+    def test_mean_shifts_toward_optimum(self):
+        """After several updates with a shifted sphere, mean should move closer to optimum."""
+        from panobbgo.heuristics import CMAES
+
+        np.random.seed(42)
+        cma = CMAES(self.strategy, sigma0=0.5, popsize=10)
+        cma.on_start()
+
+        # Sphere optimum at (1, 1) — not at box centre (0, 0)
+        optimum = np.ones(self.problem.dim)
+        initial_dist = np.linalg.norm(cma._m - optimum)
+
+        # Run 15 generations with shifted sphere
+        for _ in range(15):
+            points = cma.get_points(100)
+            results = [Result(p, float(np.sum((p.x - 1.0)**2))) for p in points]
+            cma.on_new_results(results)
+
+        final_dist = np.linalg.norm(cma._m - optimum)
+        assert final_dist < initial_dist, (
+            f"Mean did not converge: {initial_dist:.4f} -> {final_dist:.4f}"
+        )
+
+    def test_sigma_decreases_near_optimum(self):
+        """Step size should decrease after CMA-ES has converged close to optimum."""
+        from panobbgo.heuristics import CMAES
+
+        np.random.seed(7)
+        cma = CMAES(self.strategy, sigma0=0.3, popsize=8)
+        cma.on_start()
+
+        # Manually place mean at the optimum so CMA-ES immediately refines
+        cma._m = np.ones(self.problem.dim)  # Rosenbrock optimum
+        initial_sigma = cma._sigma
+
+        # Run many generations with a tight shifted sphere centred at optimum
+        for _ in range(30):
+            points = cma.get_points(100)
+            results = [Result(p, float(np.sum((p.x - 1.0)**2))) for p in points]
+            cma.on_new_results(results)
+
+        assert cma._sigma < initial_sigma * 0.95, (
+            f"sigma did not shrink near optimum: {initial_sigma:.4f} -> {cma._sigma:.4f}"
+        )
+
+    def test_ignores_foreign_results(self):
+        """Results from other heuristics should not affect CMA-ES state."""
+        from panobbgo.heuristics import CMAES
+
+        cma = CMAES(self.strategy)
+        cma.on_start()
+        _ = cma.get_points(100)  # drain initial gen
+        m_before = cma._m.copy()
+
+        # Feed results from a different heuristic
+        foreign = [
+            Result(Point(np.zeros(self.problem.dim), "RandomHeuristic"), 0.5),
+            Result(Point(np.ones(self.problem.dim), "NelderMead"), 1.5),
+        ]
+        cma.on_new_results(foreign)
+
+        # Mean should be unchanged
+        assert np.allclose(cma._m, m_before)
+
+    def test_handles_partial_results(self):
+        """Partial generation (min_results_fraction=0.5) should still trigger update."""
+        from panobbgo.heuristics import CMAES
+
+        cma = CMAES(self.strategy, popsize=8, min_results_fraction=0.5)
+        cma.on_start()
+        points = cma.get_points(100)
+        assert len(points) == 8
+
+        # Feed only half the results (4 out of 8)
+        partial = [Result(p, float(np.sum(p.x**2))) for p in points[:4]]
+        cma.on_new_results(partial)
+
+        # Should have emitted next generation
+        next_pts = cma.get_points(100)
+        assert len(next_pts) == 8
+
+    def test_handles_inf_fx_gracefully(self):
+        """Infinite fx values should be ignored."""
+        from panobbgo.heuristics import CMAES
+
+        cma = CMAES(self.strategy, popsize=6)
+        cma.on_start()
+        points = cma.get_points(100)
+
+        # Mix valid and infinite results
+        results = []
+        for i, p in enumerate(points):
+            fx = float("inf") if i % 2 == 0 else np.sum(p.x**2)
+            results.append(Result(p, fx))
+        # Should not raise
+        cma.on_new_results(results)
+
+    def test_covariance_stays_positive_definite(self):
+        """Covariance matrix should remain positive (semi-)definite."""
+        from panobbgo.heuristics import CMAES
+
+        np.random.seed(0)
+        cma = CMAES(self.strategy, sigma0=0.4, popsize=8)
+        cma.on_start()
+
+        for _ in range(15):
+            points = cma.get_points(100)
+            results = [Result(p, float(np.sum(p.x**2))) for p in points]
+            cma.on_new_results(results)
+
+        eigvals = np.linalg.eigvalsh(cma._C)
+        assert np.all(eigvals > -1e-10), f"Negative eigenvalues: {eigvals}"
+
+    def test_weights_sum_to_one(self):
+        from panobbgo.heuristics import CMAES
+
+        for lam in [4, 6, 10, 20]:
+            cma = CMAES(self.strategy, popsize=lam)
+            cma.on_start()
+            assert np.isclose(cma._w.sum(), 1.0), f"Weights don't sum to 1 (lam={lam})"
+
+    def test_chi_n_reasonable(self):
+        from panobbgo.heuristics import CMAES
+
+        cma = CMAES(self.strategy)
+        cma.on_start()
+        n = self.problem.dim
+        # chi_n ≈ sqrt(n) for large n
+        assert abs(cma._chi_n - np.sqrt(n)) < 0.5, f"chi_n={cma._chi_n}"
+
+    def test_sigma0_fraction(self):
+        """Larger sigma0 fraction should give larger initial step size."""
+        from panobbgo.heuristics import CMAES
+
+        cma1 = CMAES(self.strategy, sigma0=0.1)
+        cma2 = CMAES(self.strategy, sigma0=0.8)
+        cma1.on_start()
+        cma2.on_start()
+        assert cma2._sigma > cma1._sigma, (
+            f"sigma with sigma0=0.8 ({cma2._sigma:.4f}) should exceed "
+            f"sigma with sigma0=0.1 ({cma1._sigma:.4f})"
+        )
+
+    def test_exportable_from_package(self):
+        """CMAES must be importable from the top-level heuristics package."""
+        from panobbgo.heuristics import CMAES
+
+        assert CMAES is not None
+
+
+# ---------------------------------------------------------------------------
+# Functional test: CMA-ES on Rosenbrock 2D within a real strategy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.flaky(retries=3)
+def test_cmaes_integration_rosenbrock():
+    """End-to-end test: CMA-ES should improve upon random search on Rosenbrock 2D."""
+    from panobbgo.lib.classic import Rosenbrock
+    from panobbgo.strategies import StrategyRewarding
+    from panobbgo.heuristics import CMAES, Random, NelderMead
+
+    problem = Rosenbrock(2)
+    np.random.seed(12345)
+
+    with StrategyRewarding(
+        problem,
+        max_evaluations=150,
+        evaluation_method="threaded",
+    ) as strategy:
+        strategy.add(Random)
+        strategy.add(NelderMead)
+        strategy.add(CMAES, sigma0=0.4)
+        strategy.start()
+        best_fx = strategy.best.fx if strategy.best else float("inf")
+
+    # On Rosenbrock 2D the global minimum is 0 at (1,1).
+    # 150 evaluations should reliably reach fx < 5 with CMA-ES in the mix.
+    assert best_fx < 5.0, f"CMA-ES + NelderMead should find near-optimum; got {best_fx:.4f}"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **New `CMAES` heuristic** (`panobbgo/heuristics/cma_es.py`): pure-NumPy implementation of the canonical Covariance Matrix Adaptation Evolution Strategy (Hansen 2016), fully compatible with panobbgo's async threaded evaluation model
- **Fixed `StrategyBase.heuristic()` lookup** (`panobbgo/core.py`): handles compound `who` strings like `"CMAES:g3:i0"` and `"DifferentialEvolution:uuid"` — falls back to base name prefix, preventing `KeyError` in reward attribution
- **Added `CMAES_Portfolio` and `CMAES_GP` strategies** to standard and full benchmark harness modes; CMA-ES intentionally excluded from quick mode (75 evals is too small for covariance adaptation to converge)
- **20 new tests** (`tests/test_heuristic_cmaes.py`): init, point emission, update triggering, mean convergence, sigma decay, covariance PD, and end-to-end Rosenbrock integration
- **Docs updated**: `guide_architecture.rst` and `guide_usage.rst` document the new heuristic and recommended portfolio configurations

## Why CMA-ES?

CMA-ES is the gold standard for derivative-free optimization of continuous functions:
- Invariant under order-preserving objective transformations and orthogonal search-space rotations
- Adapts a full covariance matrix → naturally follows narrow ridges and ill-conditioned level sets (e.g. Rosenbrock)
- Self-adaptive step size (no manual tuning)
- Optimal performance requires ≥ 100 evaluations in 2D; scales well to higher dimensions

## Implementation details

- **Async generation tracking**: each emitted point gets a compound `who` tag (`"CMAES:g{gen}:i{idx}"`) so that `on_new_results` can correctly match returned results to their generation without blocking
- **Lazy eigendecomposition**: updates `B, D` only every `λ / ((c₁+cμ) · n · 10)` function evaluations for efficiency; resets to identity if condition number exceeds 10⁷
- **Partial-generation updates**: triggers update after `min_results_fraction · λ` results arrive (default 0.5 = μ), making it resilient to dropped or failed evaluations
- Points are put directly to `self._output` (bypassing the ndarray-only `emit()`) to preserve custom `who` tags — same pattern used by `DifferentialEvolution`

## Test plan

- [x] 20 unit tests all pass (`tests/test_heuristic_cmaes.py`)
- [x] Full test suite: 591 passed, 1 skipped, 1 retried (stochastic flake) — no regressions
- [x] Quick benchmark score stable: 0.483 before → 0.480 after (within stochastic noise at 3 reps)
- [x] Ruff lint clean on `cma_es.py`

https://claude.ai/code/session_01PvtwNNF9K3aTx9JgRmQcdS
EOF
)