### PR TITLE
docs: sync guide with recently added optimizers, analyzers, and strategies

### DIFF
--- a/doc/source/analyzers.rst
+++ b/doc/source/analyzers.rst
@@ -4,12 +4,13 @@ Analyzers Module
 Result analysis and monitoring components:
 
 - **Analyzer**: Base class for analysis components
-- **Best**: Tracks best solutions found
-- **Convergence**: Monitors optimization progress
-- **Sensitivity**: Estimates per-dimension importance
-- **Restart**: Detects stagnation and triggers multi-start restarts
-- **Grid**: Space partitioning for analysis
-- **Splitter**: Adaptive space subdivision
+- **Best**: Tracks best solutions found (feasible best, infeasible best, Pareto front of ``(f, CV)``)
+- **Convergence**: Monitors optimization progress; publishes a ``converged`` event using ``std`` or ``improv`` mode
+- **Sensitivity**: Estimates per-dimension importance via rank correlation; enables sensitivity-aware perturbations in ``Nearby``
+- **Restart**: Detects stagnation (no improvement within ``patience`` evaluations) and triggers multi-start restarts; pairs with CMAES for IPOP-CMA-ES
+- **Grid**: Simple spatial grid grouping of nearby points
+- **Dedensifyer**: Hierarchical grid that avoids point clustering by keeping only min/max representatives per region
+- **Splitter**: Adaptive hierarchical box-decomposition of the search space; publishes ``new_split`` and identifies the best leaf box
 
 .. automodule:: panobbgo.analyzers
    :members:

--- a/doc/source/guide_introduction.rst
+++ b/doc/source/guide_introduction.rst
@@ -79,30 +79,39 @@ Panobbgo includes diverse heuristics with different search strategies:
      - Explore broadly
    * - Local Search
      - Nearby, Weighted Average
-     - Refine around best
+     - Refine around best (Nearby is sensitivity-aware when paired with the Sensitivity analyzer)
    * - Model-Based
      - Quadratic WLS, Gaussian Process
-     - Fit surrogate, optimize (using EIC)
+     - Fit surrogate, optimize acquisition function (EI / UCB / PI, with EIC under constraints)
    * - Classical Optimizers
      - Nelder-Mead, L-BFGS-B
      - Local optimization
+   * - Population-Based
+     - CMA-ES (with optional IPOP restarts), Differential Evolution
+     - Global evolutionary search; CMA-ES excels on ill-conditioned/ridge-following problems, DE on multimodal ones
+   * - Cluster-Based
+     - ClaudeHeuristic
+     - Mixture-of-Gaussians over elite points, related to Cross-Entropy / EDA methods
    * - Constraint Handling
-     - Feasible Search, Constraint Gradient
-     - Target feasible regions
+     - Feasible Search, Constraint Gradient, Local Penalty Search, Constraint Repair
+     - Target feasible regions, minimise penalised objective, repair infeasible points
 
 Adaptive Selection
 ~~~~~~~~~~~~~~~~~~
 
-Panobbgo provides several adaptive strategies based on **multi-armed bandit** algorithms:
+Panobbgo provides several adaptive strategies based on **multi-armed bandit** algorithms, plus a
+budget-phased meta-strategy:
 
-- :class:`~panobbgo.strategies.rewarding.StrategyRewarding`: Probability-based selection with additive smoothing and performance decay.
-- :class:`~panobbgo.strategies.ucb.StrategyUCB`: Upper Confidence Bound algorithm for optimal exploration-exploitation trade-off.
-- :class:`~panobbgo.strategies.thompson.StrategyThompsonSampling`: Probabilistic approach using Beta distributions.
+- :class:`~panobbgo.strategies.rewarding.StrategyRewarding`: Probability-based selection with additive smoothing and performance decay (softmax bandit).
+- :class:`~panobbgo.strategies.ucb.StrategyUCB`: Upper Confidence Bound (UCB1) algorithm for principled exploration-exploitation trade-off.
+- :class:`~panobbgo.strategies.thompson.StrategyThompsonSampling`: Probabilistic approach using Beta-Bernoulli Thompson Sampling.
+- :class:`~panobbgo.strategies.contextual.StrategyLinUCB`: Contextual bandit (disjoint linear UCB) that uses budget progress and success-rate features to adapt heuristic selection over time.
+- :class:`~panobbgo.strategies.phased.StrategyPhased`: Meta-strategy that splits the evaluation budget into phases, each with its own sub-strategy and heuristic portfolio (e.g., LHS exploration → GP-guided exploitation).
 
 Result Analysis
 ~~~~~~~~~~~~~~~
 
-Four analyzers process results and maintain derived information:
+Analyzers process results and maintain derived information:
 
 .. list-table::
    :header-rows: 1
@@ -123,6 +132,15 @@ Four analyzers process results and maintain derived information:
    * - :class:`~panobbgo.analyzers.dedensifyer.Dedensifyer`
      - Hierarchical grid
      - Min/max representatives per region
+   * - :class:`~panobbgo.analyzers.convergence.Convergence`
+     - Recent objective statistics (std / improvement)
+     - ``converged``
+   * - :class:`~panobbgo.analyzers.sensitivity.Sensitivity`
+     - Rank-correlation-based per-dimension importance scores
+     - ``new_sensitivity``
+   * - :class:`~panobbgo.analyzers.restart.Restart`
+     - Stagnation detection and diverse restart centers
+     - ``restart`` (enables IPOP-CMA-ES when paired with CMAES)
 
 Benchmark Problems
 ~~~~~~~~~~~~~~~~~~

--- a/doc/source/guide_research.rst
+++ b/doc/source/guide_research.rst
@@ -55,13 +55,16 @@ Bayesian Optimization
 
 **Approach**: Fit Gaussian process (GP) surrogate model, optimize acquisition function
 
-**Panobbgo equivalent**: :class:`~panobbgo.heuristics.quadratic_wls_model.QuadraticWlsModel`
-uses simpler quadratic surrogate
+**Panobbgo implementation**: :class:`~panobbgo.heuristics.gaussian_process.GaussianProcessHeuristic`
+fits a Matérn-5/2 GP via scikit-learn and optimises EI / UCB / PI acquisition functions.  Uses
+Constrained Expected Improvement (EIC) automatically when the problem has active constraint
+violations.  :class:`~panobbgo.heuristics.quadratic_wls_model.QuadraticWlsModel` is retained as a
+faster, less accurate quadratic surrogate alternative.
 
 **Trade-offs**:
 
-- GP: Better uncertainty quantification, higher computational cost
-- Quadratic: Faster, scales better, but less accurate
+- GP (GaussianProcessHeuristic): Better uncertainty quantification, higher computational cost — gold standard for expensive BO
+- Quadratic (QuadraticWlsModel): Faster, scales better, but less accurate
 
 **References**: [Mockus1989]_, [Brochu2010]_
 
@@ -70,15 +73,32 @@ CMA-ES (Covariance Matrix Adaptation Evolution Strategy)
 
 **Approach**: Evolutionary algorithm with adaptive covariance matrix
 
-**Panobbgo equivalent**: :class:`~panobbgo.heuristics.nelder_mead.NelderMead`
-has similar adaptive sampling, but deterministic
+**Panobbgo implementation**: :class:`~panobbgo.heuristics.cma_es.CMAES` provides a pure-NumPy
+CMA-ES with asynchronous generation tracking that fits panobbgo's threaded evaluation model.
+When paired with :class:`~panobbgo.analyzers.restart.Restart` it becomes **IPOP-CMA-ES**
+(Increasing Population CMA-ES, Auger & Hansen CEC 2005) — the competition-winning approach on
+BBOB/COCO: each restart doubles the population λ → 2λ, resets the covariance to identity, and
+moves the mean to a diverse new center, enabling systematic escape from local optima while the
+accumulated result history is preserved.
 
 **Trade-offs**:
 
-- CMA-ES: Powerful for smooth problems, populations approach
-- NelderMead: Deterministic simplex, good for local search
+- CMA-ES: Powerful for smooth, ill-conditioned, and ridge-following problems (e.g., Rosenbrock); invariant under orthogonal search-space transformations
+- IPOP-CMA-ES: Adds multimodal robustness at the cost of extra restarts
+- NelderMead: Deterministic simplex, good for final local refinement
 
 **References**: [Hansen2001]_
+
+Differential Evolution
+~~~~~~~~~~~~~~~~~~~~~~
+
+**Approach**: Population-based mutation/crossover/selection on a population of solution vectors
+
+**Panobbgo implementation**: :class:`~panobbgo.heuristics.differential_evolution.DifferentialEvolution`
+runs DE operators against the accumulated result database.  Strong complement to CMA-ES on
+multimodal landscapes such as Rastrigin and Schwefel where purely local methods get trapped.
+
+**References**: [Storn1997]_
 
 DIRECT (Dividing Rectangles)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -234,20 +254,24 @@ Constraint Handling
 
 **Challenge**: Efficiently find feasible solutions
 
-**Current Panobbgo**: Lexicographic ordering (feasibility first)
+**Current Panobbgo**: Pluggable :class:`~panobbgo.lib.constraints.ConstraintHandler` implementations:
 
-**Alternatives**:
+- ``DefaultConstraintHandler`` — lexicographic ordering (feasibility first)
+- ``PenaltyConstraintHandler`` — static penalty :math:`f(x) + \rho \cdot cv(x)^{e}`
+- ``DynamicPenaltyConstraintHandler`` — penalty coefficient increases over time
+- ``AugmentedLagrangianConstraintHandler`` — adaptive multipliers :math:`\lambda` and penalty :math:`\mu`
+- ``EpsilonConstraintHandler`` — tolerance :math:`\epsilon(t)` shrinks towards zero
+- ``FilterConstraintHandler`` — Pareto-dominance filter on :math:`(f, cv)`
 
-- Penalty methods
-- Augmented Lagrangian
-- Constraint approximation
-- Feasibility restoration
+Complemented by constraint-focused heuristics: FeasibleSearch (line search to feasibility),
+ConstraintGradient (finite-difference constraint-gradient descent), LocalPenaltySearch
+(scipy local optimiser on the scalarised penalty), and ConstraintRepair (SLSQP projection).
 
 **Future work**:
 
-- Constraint-specific heuristics
 - Feasibility pump analyzer
-- Adaptive penalty parameters
+- Adaptive penalty parameters guided by the Sensitivity analyzer
+- Constraint approximation / surrogate-assisted repair
 
 Robust Optimization
 ~~~~~~~~~~~~~~~~~~~
@@ -288,70 +312,65 @@ Transfer Learning
 Future Directions
 -----------------
 
-Short-Term Improvements (3-6 months)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Recently Completed
+~~~~~~~~~~~~~~~~~~
 
-1. **Gaussian Process Surrogate**
+The following items from earlier roadmaps have been implemented:
 
-   - Replace :class:`~panobbgo.heuristics.quadratic_wls_model.QuadraticWlsModel` with GP
-   - Use scikit-learn or GPyTorch
-   - Implement acquisition functions (EI, UCB, PI)
+1. **Gaussian Process Surrogate** — see :class:`~panobbgo.heuristics.gaussian_process.GaussianProcessHeuristic`
+   (scikit-learn, Matérn-5/2 kernel, EI / UCB / PI acquisition, constrained EI).
+2. **Persistent Storage** — SQLite backend for :class:`~panobbgo.core.Results` with automatic
+   resume-from-checkpoint (see :mod:`panobbgo.storage`).
+3. **Convergence Detection** — :class:`~panobbgo.analyzers.convergence.Convergence` analyzer
+   with ``std`` and ``improv`` modes publishing a ``converged`` event.
+4. **Better Constraint Handling** — multiple constraint handlers (Default, Penalty,
+   DynamicPenalty, AugmentedLagrangian, Epsilon, Filter) plus constraint-focused heuristics
+   (FeasibleSearch, ConstraintGradient, LocalPenaltySearch, ConstraintRepair).
+5. **Advanced Bandit Strategies** — :class:`~panobbgo.strategies.ucb.StrategyUCB`,
+   :class:`~panobbgo.strategies.thompson.StrategyThompsonSampling`, and contextual
+   :class:`~panobbgo.strategies.contextual.StrategyLinUCB`.
+6. **Budget-Phased Meta-Strategy** — :class:`~panobbgo.strategies.phased.StrategyPhased`
+   composes different sub-strategies and heuristic portfolios across budget phases.
+7. **Population-Based Global Search** — :class:`~panobbgo.heuristics.cma_es.CMAES` with
+   IPOP restart support via :class:`~panobbgo.analyzers.restart.Restart`, and
+   :class:`~panobbgo.heuristics.differential_evolution.DifferentialEvolution`.
+8. **Sensitivity Analysis** — :class:`~panobbgo.analyzers.sensitivity.Sensitivity` with a
+   sensitivity-aware :class:`~panobbgo.heuristics.nearby.Nearby` heuristic.
+9. **Reproducible Benchmark Harness** — see :mod:`panobbgo.harness` and ``benchmark_harness.py``
+   CLI for measuring the impact of code changes on optimisation performance.
 
-2. **Persistent Storage**
+Short-Term Improvements
+~~~~~~~~~~~~~~~~~~~~~~~
 
-   - SQLite backend for :class:`~panobbgo.core.Results`
-   - Save/load optimization state
-   - Resume from checkpoint
-   - Share results across runs
-
-3. **Convergence Detection**
-
-   - Implement :class:`ConvergenceDetector` analyzer (see :doc:`guide_extending`)
-   - Statistical tests for stagnation
-   - Automatic termination
-   - Publish ``converged`` event
-
-4. **Better Constraint Handling**
-
-   - Penalty function methods
-   - Augmented Lagrangian heuristic
-   - Constraint-specific strategies
-
-5. **Enhanced Visualization**
+1. **Enhanced Visualization**
 
    - Real-time optimization plots
    - Convergence dashboards
    - Pareto front visualization
    - Heuristic performance tracking
 
-Medium-Term Research (6-12 months)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-1. **Advanced Bandit Strategies**
-
-   - UCB (Upper Confidence Bound) [Auer2002]_
-   - Thompson Sampling [Thompson1933]_
-   - Contextual bandits using problem features
-
-2. **Parallel Batch Generation**
+2. **Parallel Batch Generation (q-acquisition)**
 
    - Generate batches considering pending evaluations
    - Avoid redundant sampling (q-EI, q-UCB)
    - Optimize batch diversity
 
-3. **Multi-Fidelity Support**
+Medium-Term Research
+~~~~~~~~~~~~~~~~~~~~
+
+1. **Multi-Fidelity Support**
 
    - Multi-fidelity Problem class
    - Fidelity allocation strategy
    - Low/high-fidelity coordination
 
-4. **Dimension Reduction**
+2. **Dimension Reduction**
 
    - Random embeddings
    - Active subspace detection
-   - Coordinate importance ranking
+   - Coordinate importance ranking (building on the Sensitivity analyzer)
 
-5. **Benchmarking Suite**
+3. **Benchmarking Suite**
 
    - Standardized test problems
    - Performance profiles [Dolan2002]_
@@ -565,6 +584,10 @@ References
 .. [Mockus1989] Mockus, J. (1989).
    *Bayesian Approach to Global Optimization: Theory and Applications*.
    Kluwer Academic Publishers.
+
+.. [Storn1997] Storn, R., & Price, K. (1997).
+   Differential evolution – A simple and efficient heuristic for global optimization over continuous spaces.
+   *Journal of Global Optimization*, 11(4), 341-359.
 
 .. [Thompson1933] Thompson, W. R. (1933).
    On the likelihood that one unknown probability exceeds another in view of the evidence of two samples.

--- a/doc/source/heuristics.rst
+++ b/doc/source/heuristics.rst
@@ -8,15 +8,18 @@ Point generation algorithms (heuristics):
 - **Random**: Uniform random sampling within the best leaf box.
 - **LatinHypercube**: Stratified sampling (Space-filling).
 - **Extremal**: Samples from the boundaries of the search space.
-- **Nearby**: Gaussian perturbations around current best points.
+- **Nearby**: Gaussian perturbations around current best points (sensitivity-aware when paired with the Sensitivity analyzer).
 - **WeightedAverage**: Averages points in the best region.
-- **QuadraticWLS**: Fits a weighted least-squares quadratic surrogate model.
-- **GaussianProcess**: Uses Gaussian Process models and Expected Improvement with Constraints (EIC).
+- **QuadraticWlsModel**: Fits a weighted least-squares quadratic surrogate model.
+- **GaussianProcessHeuristic**: Gaussian Process surrogate with EI / UCB / PI acquisition functions; uses Expected Improvement with Constraints (EIC) when constraints are active.
 - **NelderMead**: Simplex optimization method.
 - **LBFGSB**: Local optimization using the L-BFGS-B algorithm.
-- **FeasibleSearch**: Actively searches for and repairs feasible solutions.
+- **CMAES**: Covariance Matrix Adaptation Evolution Strategy with IPOP-CMA-ES restart support (paired with the Restart analyzer) — gold standard for derivative-free continuous optimization, excellent on ill-conditioned/ridge-following problems like Rosenbrock.
+- **DifferentialEvolution**: DE mutation/crossover/selection applied to the accumulated result database — strong on multimodal landscapes (Rastrigin, Schwefel).
+- **FeasibleSearch**: Actively searches for and repairs feasible solutions via line search towards feasibility.
 - **ConstraintGradient**: Uses estimated gradients of constraint violations to find feasible regions.
-- **LocalPenaltySearch**: Optimizes the scalarized penalty function directly.
+- **LocalPenaltySearch**: Optimizes the scalarized penalty function directly with a local scipy optimizer.
+- **ConstraintRepair**: Projects infeasible best points onto the feasible region using SLSQP.
 - **ClaudeHeuristic**: Cluster-based adaptive search using Mixture of Gaussians over elite points.
 
 .. automodule:: panobbgo.heuristics

--- a/doc/source/strategies.rst
+++ b/doc/source/strategies.rst
@@ -5,10 +5,11 @@ Available optimization strategies:
 
 - **StrategyBase**: Abstract base class for all strategies
 - **StrategyRoundRobin**: Simple round-robin point evaluation
-- **StrategyRewarding**: Adaptive heuristic selection based on performance
-- **StrategyUCB**: Upper Confidence Bound algorithm for exploration
-- **StrategyThompsonSampling**: Probabilistic selection using Thompson Sampling
-- **StrategyPhased**: Budget-phased meta-strategy composing different sub-strategies
+- **StrategyRewarding**: Adaptive heuristic selection based on performance (softmax multi-armed bandit)
+- **StrategyUCB**: Upper Confidence Bound (UCB1) algorithm for principled exploration/exploitation
+- **StrategyThompsonSampling**: Probabilistic selection using Thompson Sampling (Beta-Bernoulli bandit)
+- **StrategyLinUCB**: Contextual bandit using disjoint linear UCB models over budget-progress / success-rate features
+- **StrategyPhased**: Budget-phased meta-strategy composing different sub-strategies and heuristic portfolios across phases
 
 .. automodule:: panobbgo.strategies
    :members:


### PR DESCRIPTION
## Summary

Audited the Sphinx documentation against the current code and brought it back into sync with recently added optimizers, analyzers, and strategies.

### API reference lists

- `doc/source/heuristics.rst`: added `CMAES`, `DifferentialEvolution`, `ConstraintRepair`; renamed `QuadraticWLS`/`GaussianProcess` to match the actual class names; noted sensitivity-awareness for `Nearby`.
- `doc/source/strategies.rst`: added `StrategyLinUCB`; expanded `StrategyPhased` description.
- `doc/source/analyzers.rst`: added `Dedensifyer`; expanded descriptions for `Convergence`, `Sensitivity`, and `Restart`.

### Guide pages

- `guide_introduction.rst`: heuristic table now has Population-Based (CMA-ES / DE) and Cluster-Based (ClaudeHeuristic) rows; strategy list includes all four bandits plus `StrategyPhased`; analyzer table covers all seven analyzers.
- `guide_research.rst`:
  - Bayesian Optimization now references `GaussianProcessHeuristic` (not `QuadraticWlsModel`).
  - CMA-ES section references the real `CMAES` heuristic and IPOP-CMA-ES support via the `Restart` analyzer.
  - New Differential Evolution entry with a `Storn1997` reference.
  - "Short-Term Improvements" items that have shipped (GP, SQLite storage, convergence detection, constraint handlers, UCB/Thompson/LinUCB, CMA-ES, DE, Sensitivity, benchmark harness) moved into a new "Recently Completed" section; the remaining roadmap is reframed around visualisation, q-acquisition batching, multi-fidelity, and dimension reduction.
  - Constraint Handling section now lists the six pluggable `ConstraintHandler` implementations and the constraint-focused heuristics.

No code changes.

## Test plan

- [ ] `cd doc && make html` builds without new warnings
- [ ] Spot-check the rendered HTML for the edited pages (heuristics, strategies, analyzers, guide_introduction, guide_research)
