### PR TITLE
docs: expand benchmark harness guide and plan self-improvement loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,14 @@ Panobbgo solves **expensive, noisy black-box optimization** problems. Key domain
 
 ## Benchmark Harness (Self-Improvement Workflow)
 
-A reproducible benchmark harness is available for measuring the impact of code changes on optimization performance. **Agents MUST use this when modifying strategies, heuristics, or core optimization logic.**
+A reproducible benchmark harness is the **single source of truth** for
+"is Panobbgo better or worse than it was before this change?".  It produces
+one scalar, ``composite_score`` ∈ [0, 1], designed to gate every change an
+agent makes. **Agents MUST use this when modifying strategies, heuristics,
+or core optimization logic.**
+
+Full guide: `doc/source/guide_benchmarking.rst`. Self-improvement plan:
+`planning/SELF_IMPROVEMENT_LOOP.md`.
 
 ### Workflow
 
@@ -77,27 +84,32 @@ uv run python benchmark_harness.py run --quick --output before.json
 uv run python benchmark_harness.py run --quick --output after.json
 
 # 4. Compare — exits with code 2 if regressions detected
-uv run python benchmark_harness.py compare before.json after.json
+uv run python benchmark_harness.py compare before.json after.json --fail-on-regression
 ```
 
 ### Modes
 
-*   `--quick`: 3 problems, 2 strategies, 3 reps, 75 evals (~30s) — use during development
-*   `--standard`: 8 problems, 3 strategies, 5 reps, 200 evals — use before merging
-*   `--full`: 11 problems, 4 strategies, 10 reps, 500 evals — thorough validation
+*   `--quick`: 3 problems × 2 strategies × 3 reps × 75 evals (~30s) — use during development
+*   `--standard`: 8 problems × ~6 strategies × 5 reps × 200 evals (~few min) — use before merging
+*   `--full`: 11 problems × ~10 strategies × 10 reps × 500 evals (~1h) — thorough validation
 
 ### Key files
 
 *   `panobbgo/harness.py` — `BenchmarkHarness` class, metrics, serialization, comparison
 *   `benchmark_harness.py` — CLI tool (`run`, `score`, `compare`, `list` subcommands)
 *   `tests/test_harness.py` — comprehensive test suite for the harness itself
+*   `doc/source/guide_benchmarking.rst` — user-facing guide
+*   `planning/SELF_IMPROVEMENT_LOOP.md` — design for autonomous improvement loop
 
 ### Score interpretation
 
-*   **1.0** = solved at first evaluation (theoretical best)
-*   **0.7+** = good; strategies consistently find optima efficiently
-*   **0.3** = poor; strategies rarely find optima
-*   **0.0** = never found any optimum
+*   **1.0** = every run solves at evaluation 1 (theoretical ceiling)
+*   **0.7+** = strong; strategies consistently find optima with budget left over
+*   **0.3** = weak; rare successes, usually late in the budget
+*   **0.0** = never found any optimum within tolerance
+
+Per-pair metrics also reported: ``success_rate``, ``ert`` (BBOB standard),
+``best_func_distance``, ``median_func_distance``.
 
 ### When to use
 
@@ -105,6 +117,33 @@ uv run python benchmark_harness.py compare before.json after.json
 *   Modifying any heuristic (`heuristics/`)
 *   Changing core evaluation or constraint handling logic
 *   Adding new benchmark problems or strategies to the registry
+
+### Statistical rigor
+
+The composite score is **noisy** at `--quick` mode (3 reps). A delta of
+±0.02 is within noise.
+
+*   Treat quick-mode deltas as *trend signals*, not proof.
+*   For deltas in the `+0.01` to `+0.03` range, re-run at a second seed
+    (`--seed 43`) before accepting the change.
+*   Before merging a significant algorithmic change, run `--standard` or
+    `--full` on a machine you are not actively using.
+*   The composite-score formula itself is a **stable contract**:  do not
+    change it without an architectural decision record — historical
+    comparisons depend on it.
+
+### Agent self-improvement loop (in progress)
+
+The harness is the measurement substrate for an autonomous
+"measure → propose → apply → measure → accept/revert" loop. See
+`planning/SELF_IMPROVEMENT_LOOP.md` for:
+
+*   The parametrically-randomised problem battery (rotations, shifts,
+    conditioning, noise) that prevents over-fitting to fixed instances.
+*   External absolute baselines (scipy DE, CMA-ES, random search) so the
+    number judges Panobbgo in absolute, not just relative, terms.
+*   Statistical acceptance rules (bootstrap CI on score delta).
+*   Phased rollout from MVP to production loop.
 
 ## CI/CD and Testing
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,34 @@
 
 ## Recent Improvements
 
+### Benchmark Harness Documentation & Self-Improvement Plan (2026-04-19)
+- [x] **New Sphinx guide** (`doc/source/guide_benchmarking.rst`)
+  - Full definition of `composite_score` with math, interpretation table, pitfalls
+  - Documents the `quick`/`standard`/`full` modes, reproducibility model, `compare` workflow
+  - Sections on statistical caveats, parametric randomization (planned), absolute baselines (planned)
+  - Wired into `doc/source/guide.rst` toctree
+- [x] **Expanded `AGENTS.md`** Benchmark Harness section
+  - Statistical rigor subsection (quick-mode noise, re-run at alt seed before accepting small deltas)
+  - Self-improvement loop pointer
+  - Explicit "composite score formula is a stable contract" note
+- [x] **Enriched module docstrings** (`panobbgo/harness.py`, `benchmark_harness.py`)
+  - Explicit composite-score formula with per-run solve fraction `s = 1 - (k* - 1)/B`
+  - Stability contract for the formula
+  - Pointers to the guide and self-improvement plan
+- [x] **New plan** (`planning/SELF_IMPROVEMENT_LOOP.md`)
+  - Vision for measure→propose→apply→measure→accept/revert loop against randomized problems
+  - Parametric problem battery design (translate/rotate/scale/noise/dim sampling)
+  - External absolute baselines (scipy DE, dual_annealing, pycma, random)
+  - Bootstrap-CI-based statistical acceptance rule + anti-cherry-pick guard
+  - Safety rails (dedicated branch, atomic commits, test gating, STOP sentinel)
+  - Six-phase rollout from MVP to production loop + success criteria
+
+### Known gap (tracked in plan)
+- [ ] Parametric randomization of benchmark problems — plan Phase 3
+- [ ] External absolute baselines in the harness — plan Phase 2
+- [ ] Statistical acceptance rule (bootstrap CI) in `compare` — plan Phase 4
+- [ ] Loop driver `scripts/self_improve.py` — plan Phase 5
+
 ### IPOP-CMA-ES Restart Support (2026-04-19)
 - [x] **Added IPOP restart to `CMAES` heuristic** (`panobbgo/heuristics/cma_es.py`)
   - `on_restart(center, reason)` handler: moves search mean to new center, doubles λ (IPOP)

--- a/benchmark_harness.py
+++ b/benchmark_harness.py
@@ -17,8 +17,11 @@
 Benchmark Harness CLI
 =====================
 
-Command-line interface for the panobbgo benchmark harness, designed as the
-primary tool for agent-driven unsupervised improvement cycles.
+Command-line interface for the Panobbgo benchmark harness, designed as the
+primary tool for agent-driven unsupervised improvement cycles.  This CLI
+wraps :class:`panobbgo.harness.BenchmarkHarness` — see that module for the
+full composite-score definition and see ``doc/source/guide_benchmarking.rst``
+for the user-facing guide.
 
 Subcommands
 -----------
@@ -31,14 +34,22 @@ Subcommands
         uv run python benchmark_harness.py run --standard --output after.json
 
 ``score``
-    Print the composite score and per-pair breakdown for a result file::
+    Print the composite score and per-pair breakdown for a result file.
+    Add ``--json`` for a machine-readable summary aimed at coding agents::
 
-        uv run python benchmark_harness.py score results.json
+        uv run python benchmark_harness.py score results.json --json
 
 ``compare``
     Compare two result files and show what improved or degraded::
 
         uv run python benchmark_harness.py compare before.json after.json
+        uv run python benchmark_harness.py compare before.json after.json --fail-on-regression
+
+``list``
+    Enumerate available problems and strategies for a given mode — useful
+    when restricting a run with ``--problems`` or ``--strategies``::
+
+        uv run python benchmark_harness.py list --standard
 
 Typical agent loop
 ------------------
@@ -55,17 +66,30 @@ Typical agent loop
 
 4. Compare::
 
-       uv run python benchmark_harness.py compare baseline.json candidate.json
+       uv run python benchmark_harness.py compare baseline.json candidate.json --fail-on-regression
 
-5. Keep changes if ``composite_score`` improved; revert otherwise.
+5. Keep changes if ``composite_score`` improved and the process exited
+   ``0``; revert otherwise.
 
 6. Repeat.
+
+The ``planning/SELF_IMPROVEMENT_LOOP.md`` document describes how this CLI
+fits into a fully autonomous improvement loop (parametrically-randomised
+problem battery, external baselines, statistical acceptance rule).
+
+Statistical pitfalls
+--------------------
+
+The composite score is noisy at ``--quick`` mode (3 reps).  Treat deltas
+of ±0.02 as within noise.  For small deltas, re-run at a second base seed
+(``--seed 43``) before accepting a change; for significant algorithmic
+changes, re-run at ``--standard`` or ``--full``.
 
 Exit codes
 ----------
 - ``0`` – success
 - ``1`` – argument/file error
-- ``2`` – candidate is worse than baseline (useful for scripted gating)
+- ``2`` – candidate is worse than baseline (for scripted gating)
 """
 
 from __future__ import annotations

--- a/doc/source/guide.rst
+++ b/doc/source/guide.rst
@@ -40,6 +40,8 @@ Quick Navigation
      - Check :doc:`guide_extending` for adding custom heuristics, analyzers, and problems
    * - **Interested in research?**
      - Explore :doc:`guide_research` for related work, theoretical properties, and future directions
+   * - **Want to measure progress?**
+     - Read :doc:`guide_benchmarking` for the composite score and the self-improvement loop
 
 Guide Contents
 --------------
@@ -53,6 +55,7 @@ Guide Contents
    guide_architecture
    guide_usage
    guide_extending
+   guide_benchmarking
    guide_research
 
 Key Concepts

--- a/doc/source/guide_benchmarking.rst
+++ b/doc/source/guide_benchmarking.rst
@@ -1,0 +1,297 @@
+Benchmarking and the Composite Score
+====================================
+
+This chapter explains *how we measure the quality of Panobbgo* — what number
+we track, what it means, how to compute it, and how it feeds the planned
+self-improvement loop.
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Why a single number?
+--------------------
+
+Black-box optimization has no shortage of metrics: success rate, ERT
+(Expected Running Time), best distance to optimum, area under the convergence
+curve, wall-clock time. Each captures a facet, none captures the whole.
+
+For iterative, agent-driven self-improvement we need **one scalar** that:
+
+1. Lives in a bounded, comparable range (``[0, 1]``).
+2. Is monotonic in "doing better" — no artificial ceilings.
+3. Penalises both *failing to solve* and *solving slowly*.
+4. Is cheap enough to compute that it can gate every code change.
+
+The :class:`~panobbgo.harness.BenchmarkHarness` exposes exactly this number as
+``HarnessResult.composite_score``.
+
+
+Definition
+----------
+
+For each optimization run we track a *convergence trace* — the sequence of
+evaluation indices at which the best-so-far value improved. From the trace we
+extract the **first-hit evaluation** :math:`k^\star`, defined as the first
+index whose ``func_distance = |f_best − f_opt|`` is within the tolerance.
+
+Per-run "solve fraction":
+
+.. math::
+
+   s = \begin{cases}
+     1 - \dfrac{k^\star - 1}{B} & \text{if the run solved (} k^\star \le B \text{)} \\
+     0                          & \text{otherwise}
+   \end{cases}
+
+where :math:`B` is the evaluation budget.  This is in :math:`(0, 1]` for
+successful runs: ``1`` means "solved on the first evaluation",
+:math:`1/B` means "solved on the very last evaluation". Failure always scores
+``0``, so even a last-evaluation success is strictly better than no success.
+
+Per **(problem, strategy)** pair we average :math:`s` across repetitions.
+The final ``composite_score`` is the unweighted mean over all pairs.
+
+See :meth:`panobbgo.harness.ProblemStrategyResult.compute_metrics` for the
+exact implementation.
+
+
+Interpretation
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 85
+
+   * - Score
+     - Meaning
+   * - ``1.0``
+     - Theoretical ceiling — every run solves at evaluation 1.
+   * - ``0.7+``
+     - Strong. Strategies consistently locate the optimum with budget left over.
+   * - ``0.4 – 0.7``
+     - Mixed. Typical of hard multimodal problems or under-powered strategies.
+   * - ``0.1 – 0.3``
+     - Weak. Usually succeeds only near the budget limit, or rarely succeeds.
+   * - ``0.0``
+     - Never found any optimum within tolerance on any problem.
+
+
+Also reported
+~~~~~~~~~~~~~
+
+Alongside ``composite_score`` each pair exposes:
+
+- ``success_rate`` — fraction of reps hitting tolerance.
+- ``ert`` — Expected Running Time in evaluations, the BBOB/COCO standard.
+  ``inf`` when no rep succeeded.
+- ``best_func_distance`` / ``median_func_distance`` — absolute gap to optimum.
+
+Together these let you diagnose *why* the composite score moved, not just that
+it moved.
+
+
+Running benchmarks
+------------------
+
+The CLI lives at the repository root.  Always prefix with ``uv run`` so the
+correct environment is used.
+
+.. code-block:: bash
+
+   # Quick — ~30 seconds, 3 problems × 2 strategies × 3 reps, 75 evals each.
+   uv run python benchmark_harness.py run --quick --output before.json
+
+   # Make changes to panobbgo ...
+
+   uv run python benchmark_harness.py run --quick --output after.json
+   uv run python benchmark_harness.py compare before.json after.json
+
+Three preset modes trade cost against statistical power:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 15 15 15 15 25
+
+   * - Mode
+     - Problems
+     - Strategies
+     - Reps
+     - Budget
+     - Typical wall-clock
+   * - ``quick``
+     - 3
+     - 2
+     - 3
+     - 75
+     - ~30 s
+   * - ``standard``
+     - 8
+     - ~6
+     - 5
+     - 200
+     - few minutes
+   * - ``full``
+     - 11
+     - ~10
+     - 10
+     - 500
+     - ~1 hour
+
+Reproducibility
+~~~~~~~~~~~~~~~
+
+Seeds are deterministic: each ``(problem, strategy, rep)`` triple derives its
+seed via SHA-256 from a base seed (default ``42``). Re-running with the same
+base seed produces byte-identical convergence traces. See
+:meth:`panobbgo.harness.BenchmarkHarness._derive_seed`.
+
+
+The ``compare`` workflow
+------------------------
+
+``compare before.json after.json`` reports:
+
+- Composite-score delta and relative percent change.
+- Per-pair improved / degraded / unchanged classification, gated by ``--eps``
+  (default ``0.01``).
+- Pairs that exist in only one file (e.g. you added a new strategy).
+- With ``--fail-on-regression``, the process exits ``2`` when the candidate
+  scores worse.  Useful for CI gating and automated accept/revert loops.
+
+
+When to run which mode
+----------------------
+
+- **During development** — ``--quick`` after each meaningful change.  Fast
+  enough to keep you honest without hurting flow.
+- **Before opening a PR** — ``--standard``.  Saves the result JSON as a build
+  artefact so reviewers can compare.
+- **Before merging a significant algorithmic change** — ``--full``, on a
+  machine you are not actively using.
+
+
+Pitfalls and statistical caveats
+--------------------------------
+
+The composite score is **noisy**. Three symptoms to watch for:
+
+1. **Few reps** — ``--quick`` uses only 3 reps per pair. A delta of ``±0.02``
+   is firmly within noise. Treat quick-mode comparisons as trend signals, not
+   proof.
+2. **Lucky seeds** — if a regression vanishes when you change the base seed
+   (``--seed``), the effect was seed-specific, not a real improvement.
+3. **Problem-specific over-fitting** — improving on a fixed problem set does
+   not imply generalisation. This is the *central motivation* for the
+   parametrically randomised battery described below.
+
+Recommended practice: run the same comparison at two different base seeds
+before accepting a ``+0.01`` to ``+0.03`` delta.
+
+
+Parametrically randomised problems (planned)
+---------------------------------------------
+
+The current registry (``_make_quick_problems`` etc. in
+``panobbgo/harness.py``) uses *fixed* problem instances. This is great for
+A/B reproducibility but vulnerable to over-fitting: an agent that tunes a
+heuristic to the specific Rosenbrock valley at ``(1, 1)`` may regress on the
+next problem it encounters.
+
+The roadmap adds a **parametric problem layer** that samples fresh instances
+from a family each harness run:
+
+- **Translation** — shift the optimum ``x*`` to a random point in the box.
+- **Rotation** — for functions separable in the canonical frame (Rastrigin,
+  Ackley), apply a random orthogonal transform so that axis-aligned local
+  search is no longer privileged.
+- **Scaling** — sample ill-conditioning factors (e.g. log-uniform in
+  ``[1, 1e4]``) to stress second-order-aware heuristics.
+- **Noise injection** — additive Gaussian noise on evaluations, mirroring the
+  real noisy-black-box use case.
+- **Dimensionality sampling** — draw ``d`` uniformly from a stated set.
+
+Each harness run will log the per-instance parameters so that individual
+failures remain reproducible; the *aggregate* score, computed across many
+sampled instances, becomes a meaningful generalisation signal.
+
+Design details: see ``planning/SELF_IMPROVEMENT_LOOP.md``.
+
+
+Absolute baselines (planned)
+----------------------------
+
+The harness currently reports *Panobbgo strategies vs. Panobbgo strategies*.
+To judge Panobbgo in absolute terms we need external reference solvers in the
+same harness:
+
+- ``scipy.optimize.differential_evolution``
+- ``scipy.optimize.dual_annealing``
+- ``pycma`` (pure CMA-ES)
+- uniform random search (floor)
+
+These establish:
+
+- A **floor** (random search) — anything better is actually optimising.
+- A **ceiling** (tuned DE / CMA-ES) — how far is Panobbgo from well-engineered
+  solvers on the same budget?
+
+See the plan document for the integration interface.
+
+
+Self-improvement loop
+---------------------
+
+The benchmark harness is the *measurement substrate* for an autonomous
+improvement loop:
+
+1. Capture baseline composite score.
+2. Propose a change (heuristic tweak, new analyzer, parameter retune).
+3. Apply in an isolated branch; run the benchmark.
+4. Accept if ``delta > eps`` with statistical confidence; revert otherwise.
+5. Commit and repeat.
+
+Design and phased roadmap: ``planning/SELF_IMPROVEMENT_LOOP.md`` in the
+repository.
+
+
+Extending the harness
+---------------------
+
+Adding a problem
+~~~~~~~~~~~~~~~~
+
+1. Append a :class:`~panobbgo.benchmark.ProblemSpec` to the appropriate
+   ``_make_*_problems`` factory in ``panobbgo/harness.py``.
+2. Provide ``known_optima`` and a ``tolerance`` that is achievable for the
+   mode's budget but not trivially so.
+3. Run ``--quick`` to confirm the new problem is well-formed.
+
+Adding a strategy
+~~~~~~~~~~~~~~~~~
+
+1. Append a :class:`~panobbgo.benchmark.StrategySpec` to
+   ``_make_*_strategies``.
+2. The strategy must be deterministic given a seed (no external randomness
+   outside the seeded ``numpy`` generator).
+3. Validate with ``benchmark_harness.py list --standard``.
+
+Adding a metric
+~~~~~~~~~~~~~~~
+
+Per-pair aggregates live on
+:class:`~panobbgo.harness.ProblemStrategyResult`. Add a field, populate it in
+``compute_metrics``, surface it in ``HarnessResult.print_summary`` and
+``cmd_score``'s JSON path. Do **not** change the composite score formula
+without an ADR — historical comparisons depend on its stability.
+
+
+See also
+--------
+
+- :mod:`panobbgo.harness` — the harness implementation.
+- ``benchmark_harness.py`` — CLI.
+- ``tests/test_harness.py`` — test suite (60+ tests).
+- ``planning/SELF_IMPROVEMENT_LOOP.md`` — roadmap for the autonomous
+  improvement loop.

--- a/panobbgo/harness.py
+++ b/panobbgo/harness.py
@@ -20,37 +20,73 @@ Benchmark Harness
 
 Reproducible benchmark harness for automated agent feedback loops.
 
-This module provides a self-contained, reproducible benchmark system designed
-for iterative improvement cycles where a coding agent runs benchmarks, makes
-changes, and needs concrete quantitative feedback on whether improvements occurred.
+This module is the *measurement substrate* of Panobbgo: it produces one
+scalar, :attr:`HarnessResult.composite_score` ∈ ``[0, 1]``, that captures
+how well the framework is doing on a fixed battery of problems under a
+fixed set of strategies. Every code change that touches optimisation logic
+is expected to be gated against this number.
 
-Key features:
+For the full user-facing guide (interpretation, workflow, pitfalls,
+roadmap) see ``doc/source/guide_benchmarking.rst``. For the planned
+autonomous self-improvement loop that builds on top of this harness, see
+``planning/SELF_IMPROVEMENT_LOOP.md``.
 
-- **Single composite score** in [0, 1] for easy before/after comparison
-- **Reproducible** via seeded random states per run
-- **Convergence tracking** per run for diagnosing optimization behaviour
-- **ERT (Expected Running Time)** computation – the standard BBOBench metric
-- **JSON serialization** for agent-readable structured output
-- **Three modes**: ``quick`` (fast iteration), ``standard``, ``full``
-- **Comparison tool** to diff two result files
+Key features
+------------
 
-Typical agent workflow::
+- **Single composite score** in ``[0, 1]`` for easy before/after comparison.
+- **Reproducible** via SHA-256-derived seeds per ``(problem, strategy, rep)``.
+- **Convergence tracking** per run — all improvement events are recorded,
+  so the first-hit evaluation is always recoverable.
+- **ERT (Expected Running Time)** — the BBOB / COCO standard metric.
+- **JSON serialisation** so results can be diffed by a coding agent or CI.
+- **Three modes**: ``quick`` (fast iteration), ``standard``, ``full``.
+- **Comparison tool** with per-pair classification of improvements and
+  regressions.
 
-    # Run benchmarks, save results
+Composite score — formula
+-------------------------
+
+For each run with budget ``B`` we extract the first-hit evaluation
+``k* = first index where |f_best - f_opt| ≤ tolerance``.  The per-run
+"solve fraction" is::
+
+    s = 1 - (k* - 1) / B    if the run solved (k* ≤ B)
+        0                   otherwise
+
+- ``1`` means "solved on evaluation 1" (theoretical ceiling).
+- ``1/B`` means "solved on the very last evaluation".
+- Failure scores ``0`` — strictly worse than any successful run, even a
+  last-evaluation one.
+
+Per ``(problem, strategy)`` pair we average ``s`` across repetitions.
+The final composite score is the unweighted mean over all pairs.
+
+Score interpretation
+--------------------
+
+- ``1.0`` — theoretical best; every run solves at evaluation 1.
+- ``0.7+`` — strong; consistently finds optima with budget left over.
+- ``0.3`` — weak; rare successes, usually late in the budget.
+- ``0.0`` — never found any optimum within tolerance.
+
+**Stability contract**: the composite score formula is a stable contract.
+Historical before/after comparisons depend on it.  Do not change it without
+an architectural decision record.
+
+Typical agent workflow
+----------------------
+
+::
+
     uv run python benchmark_harness.py run --quick --output before.json
-
-    # ... make changes to panobbgo ...
-
-    # Run again and compare
+    # ... make changes ...
     uv run python benchmark_harness.py run --quick --output after.json
     uv run python benchmark_harness.py compare before.json after.json
 
-Score interpretation:
-
-- ``1.0`` – every run found the global optimum on the first evaluation (theoretical)
-- ``0.7`` – good; strategies consistently find optima efficiently
-- ``0.3`` – poor; strategies rarely find optima or only after many evaluations
-- ``0.0`` – never found any optimum
+The exit code of ``compare --fail-on-regression`` is ``2`` if the
+candidate scores worse, which makes this usable as a CI gate or an
+automated revert trigger inside a self-improvement loop.
 """
 
 from __future__ import annotations

--- a/planning/SELF_IMPROVEMENT_LOOP.md
+++ b/planning/SELF_IMPROVEMENT_LOOP.md
@@ -1,0 +1,321 @@
+# Self-Improvement Loop: Design & Roadmap
+
+**Status:** proposal / living document
+**Owner:** Panobbgo maintainers + coding agents
+**Related:** `panobbgo/harness.py`, `doc/source/guide_benchmarking.rst`,
+`AGENTS.md` — Benchmark Harness section.
+
+## 1. Vision
+
+Run Panobbgo in a loop that *improves itself*: measure → propose a change →
+apply → measure → accept if better, revert otherwise — against a battery
+of **standardized but parametrically randomized** tests. The loop should be
+trustworthy enough to run unattended, and honest enough that a sustained
+positive trend means the framework really got better, not that it over-fit
+to a fixed benchmark set.
+
+Three properties make this hard, and each maps to a component of the
+design below:
+
+1. **Over-fitting**. A fixed benchmark lets an agent tune to quirks
+   of the specific instances. ➜ Parametric randomization of problems.
+2. **Noise**. Stochastic strategies + a small number of reps produce
+   deceptive deltas. ➜ Statistical acceptance rule.
+3. **No absolute anchor**. Internal comparisons cannot tell us whether
+   Panobbgo is good in absolute terms. ➜ External baselines in the same
+   harness.
+
+## 2. Where we are today
+
+What exists (as of 2026-04-19):
+
+- `panobbgo/harness.py` — `BenchmarkHarness` with seeded reproducibility,
+  convergence traces, ERT, JSON serialization.
+- `benchmark_harness.py` CLI — `run` / `score` / `compare` / `list`.
+- `tests/test_harness.py` — ~60 tests.
+- Three preset modes: `quick`, `standard`, `full`.
+- Single scalar `composite_score` ∈ [0, 1] as the primary metric.
+- Manual workflow: a human (or agent) runs `compare` and decides.
+
+What's missing for a true self-improvement loop:
+
+- [ ] Parametric randomization — all problem instances are currently fixed.
+- [ ] External absolute baselines (scipy DE, pycma, random search).
+- [ ] Statistically principled accept/reject (only a naive `eps` threshold
+      today).
+- [ ] A driver that closes the loop: apply change, measure, accept/revert,
+      commit.
+- [ ] A change catalog — the space of mutations the loop may try.
+- [ ] Persistence of the running "ladder" of best composite scores over time.
+
+## 3. Architecture of the loop
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  LOOP DRIVER (new: scripts/self_improve.py)                     │
+│                                                                 │
+│  for i in range(iterations):                                    │
+│      1. baseline = measure(current HEAD)                        │
+│      2. proposal = pick_mutation(history)                       │
+│      3. apply(proposal)  # in a dedicated git branch/commit     │
+│      4. candidate = measure(HEAD with proposal)                 │
+│      5. decision = accept_reject(baseline, candidate)           │
+│         - statistical test on per-pair scores                   │
+│         - hard gate: no pair may regress by > max_regression    │
+│      6. if accept: keep commit, advance ladder                  │
+│         else:      revert, log, bias sampler away from proposal │
+│      7. periodically: full run + external baselines             │
+└─────────────────────────────────────────────────────────────────┘
+         │                     │                        │
+         ▼                     ▼                        ▼
+   Parametric            Change catalog          External baselines
+   problem sampler       (mutation space)        (scipy DE, pycma, …)
+```
+
+## 4. Parametric problem battery
+
+### 4.1 What to randomize
+
+Given a base problem `P` (e.g. Rastrigin), each harness run samples a
+**transformed instance** `P̃ = T(P; θ)` with:
+
+| Transform     | Parameter                                | Why                                        |
+|---------------|------------------------------------------|--------------------------------------------|
+| Translation   | `x* ∼ Uniform(box)`                      | kills hard-coded center exploitation       |
+| Rotation      | random orthogonal `Q ∈ O(d)`             | breaks axis-aligned local search advantage |
+| Scaling       | diagonal `Λ`, `log₁₀ cond ∼ U[0, 4]`     | stresses second-order / ill-conditioning   |
+| Noise         | `f̃(x) = f(x) + σ·ε`, `σ ∈ {0, 1e-3, 1e-2}` | matches noisy black-box use case           |
+| Dimension     | `d ∼ choice({2, 5, 10})`                 | prevents per-dim overfit                   |
+| Box shift     | box translated with optimum              | the optimum is not at a corner             |
+
+Not every problem supports every transform (Schwefel's optimum is
+non-trivial to rotate, Griewank's oscillation pattern couples to rotation).
+The sampler declares per-problem capability flags.
+
+### 4.2 Sampler interface (sketch)
+
+```python
+@dataclass
+class ProblemFamily:
+    name: str                        # "Rastrigin"
+    base_class: type                 # panobbgo.lib.classic.Rastrigin
+    supported_transforms: set[str]   # {"translate", "rotate", "noise", "scale"}
+    dim_choices: tuple[int, ...]     # (2, 5, 10)
+    f_opt: float = 0.0               # invariant under the supported transforms
+
+class ProblemSampler:
+    def sample(self, rng: np.random.Generator) -> ProblemSpec:
+        """Draw one concrete instance. Returns a ProblemSpec whose
+        `problem_class` is a wrapper that applies T in `eval()` and
+        reports the true (transformed) optimum location to the harness."""
+```
+
+### 4.3 Reproducibility under randomization
+
+The sampler's `rng` is seeded with
+`sha256(base_seed, iteration_id, problem_name, rep) → uint32` — the same
+scheme we already use for run seeds. This means:
+
+- An entire loop iteration is replayable from a single `(base_seed,
+  iteration_id)` pair.
+- A regression flagged by the loop can be reproduced deterministically
+  for debugging.
+- Across iterations the instances are *different* — which is the point —
+  but within an iteration `before` and `after` see the **same** sampled
+  instances, so the comparison is apples-to-apples.
+
+### 4.4 Impact on the composite score
+
+The composite-score formula is unchanged. What changes is the *distribution*
+it's computed over: it becomes a Monte-Carlo estimate of expected
+performance on the problem family, not a point estimate on a fixed
+instance. This makes it:
+
+- Higher-variance per iteration (good reps matter more).
+- Much less susceptible to over-fitting (the score the agent is climbing
+  is the true generalisation signal).
+- Comparable across iterations *in expectation* — exact equality is no
+  longer expected, and that's correct.
+
+## 5. External absolute baselines
+
+Without external reference solvers, the composite score only answers
+"is Panobbgo better than its previous self". We add three baselines, all
+fitted into the same `StrategySpec` interface:
+
+| Baseline        | Purpose            | Source                                   |
+|-----------------|--------------------|------------------------------------------|
+| `Random`        | floor              | uniform samples, best-so-far bookkeeping |
+| `SciPyDE`       | competitive ref    | `scipy.optimize.differential_evolution`  |
+| `SciPyAnneal`   | competitive ref    | `scipy.optimize.dual_annealing`          |
+| `PyCMA`         | state-of-the-art   | `pycma.fmin`                             |
+
+Integration notes:
+
+- Wrap each in an adapter that obeys the harness budget (`max_evaluations`)
+  and emits the same convergence trace format.
+- Seed each wrapper from the run's SHA-256-derived seed.
+- Run baselines only at `--standard` and `--full`, not at `--quick`
+  (external solvers have non-trivial per-call overhead).
+- Report them in the score table alongside Panobbgo strategies — the
+  composite is still averaged only over Panobbgo strategies, but the user
+  can see the baseline column.
+
+With baselines in place, the README can quote a single memorable number
+like "Panobbgo reaches 82% of CMA-ES's composite score on the standard
+battery at equal budget" — which actually tells people something.
+
+## 6. Statistical acceptance rule
+
+Naive "did composite go up?" is too noisy. The loop driver uses:
+
+### 6.1 Per-pair bootstrap CI
+
+For each `(problem, strategy)` pair we have N reps (≥ 5). The pair's score
+is a mean of per-rep solve fractions. Bootstrap with 10 000 resamples to
+get a 95% CI on the delta `after − before`.
+
+### 6.2 Decision rule
+
+Let `Δ = composite_after − composite_before` and let `r_i` be the per-pair
+deltas.
+
+- **Accept** iff:
+  - `Δ > ε_accept` (default `0.005`) — moved in the right direction beyond
+    measurement noise, **and**
+  - lower bound of the bootstrap 95% CI on `Δ` is `> 0` (statistically
+    plausible as a real improvement), **and**
+  - `min_i r_i > −ε_regress` (default `−0.05`) — no pair regresses
+    catastrophically, even if the average improves.
+
+- **Reject** otherwise. Revert the commit.
+
+### 6.3 Anti-cherry-pick guard
+
+Every Kth iteration (default `K = 10`), re-measure the accepted ladder on
+a *fresh* random seed. If the ladder drops more than `ε_ladder` (default
+`0.02`) on that re-measurement, roll back to the last iteration whose
+fresh-seed score is still within tolerance. This catches over-fitting to
+the particular stream of sampled problems.
+
+## 7. Change catalog
+
+The mutation space the loop may sample from, in rough order of safety:
+
+1. **Hyperparameter retunes** — `Nearby.radius`, `CMAES.sigma0`,
+   `Sensitivity.update_interval`, bandit temperatures. Bounded perturbation
+   of current value (log-uniform ±30%).
+2. **Strategy portfolio composition** — add/drop a heuristic from a
+   strategy, reweight initial priors.
+3. **Analyzer parameters** — `Restart.patience`, `Sensitivity` window.
+4. **Heuristic code edits** — delegated to a coding agent with a narrow
+   task description; applied behind a feature flag if the change is
+   non-trivial.
+5. **New heuristic / analyzer scaffolds** — manual review required; loop
+   can propose but not commit these.
+
+Each mutation has a **rollback plan** (typically `git revert HEAD`). The
+loop refuses to apply a mutation whose rollback is unclear.
+
+## 8. Safety rails
+
+- **Dedicated branch** — the loop runs on a branch like
+  `auto/improve-YYYYMMDD`. Never touches `main`.
+- **Atomic commits** — one commit per accepted mutation. Easy revert.
+- **Budget cap** — wall-clock cap per iteration (default 5 minutes for
+  quick-mode loop, 1 hour for standard-mode loop).
+- **Timeouts** — per-run timeout already enforced by `HarnessConfig.timeout_per_run`.
+- **Sanity tests** — before any iteration, run `./test.sh`. A mutation
+  that breaks tests is auto-reverted even if composite improved.
+- **Human escape hatch** — loop writes a ledger
+  (`planning/self_improve_ledger.jsonl`, one line per iteration) that a
+  human can audit, and a `STOP` sentinel file that halts the loop.
+
+## 9. Phased rollout
+
+Each phase is independently deliverable and keeps the framework usable.
+
+### Phase 0 — Documentation (this PR)
+
+- `doc/source/guide_benchmarking.rst` — the user-facing guide.
+- `AGENTS.md` and `CLAUDE.md` updated with self-improvement context.
+- Richer module docstrings on `harness.py` and `benchmark_harness.py`.
+- This plan document.
+
+### Phase 1 — Capture an absolute number (~1 day)
+
+- Run `--standard` on main, save as `planning/baseline_standard.json`.
+- Publish the current composite score in the README ("Panobbgo current
+  score: X.XX on the standard battery at base seed 42").
+- Add a `benchmark_harness.py score --json` diff as a CI artefact on
+  every PR so reviewers see the before/after.
+
+### Phase 2 — External baselines (~3-5 days)
+
+- Implement `Random`, `SciPyDE`, `SciPyAnneal`, `PyCMA` wrappers in a new
+  `panobbgo/harness_baselines.py`.
+- Register them as `StrategySpec`s selectable via a `--baselines` flag
+  on `benchmark_harness.py run`.
+- Document the gap between Panobbgo and the strongest baseline.
+
+### Phase 3 — Parametric randomization (~1-2 weeks)
+
+- Implement `ProblemFamily` and `ProblemSampler`.
+- Refactor `_make_*_problems` into family-based factories.
+- Add per-family transform capability flags.
+- New mode `--randomized-{quick,standard,full}` (fixed modes stay for
+  byte-identical reproducibility when needed).
+- Extend tests to cover sampler determinism.
+
+### Phase 4 — Statistical acceptance (~3-5 days)
+
+- Add bootstrap CI computation to `compare` output.
+- New CLI flag `compare --statistical` switches the accept rule to the
+  one described in §6.2.
+- Surface per-pair CI in the JSON output.
+
+### Phase 5 — Loop driver MVP (~1 week)
+
+- `scripts/self_improve.py` implementing §3.
+- Start with a **hyperparameter-only** mutation space (§7, item 1).
+- Runs for N iterations on a dedicated branch, writes the ledger.
+- Produces a human-readable report at the end.
+
+### Phase 6 — Production loop (ongoing)
+
+- Broaden the mutation space.
+- Connect the loop to CI (nightly run on a dedicated runner).
+- Publish the ladder in the docs.
+
+## 10. Open questions
+
+- **How much compute?** Even `--standard` with 6 strategies × 8 problems ×
+  5 reps = 240 runs per iteration. A phase-5 loop aiming for 100 iterations
+  is 24 000 runs. Realistic on a single node overnight; less realistic in
+  CI. The loop should be cloud-amenable (Dask is already supported).
+- **What if the accept rate is too low?** Most proposed mutations will be
+  no-ops or regressions. This is normal; the loop needs patience or a
+  smarter proposer (a simple Bayesian optimiser over the hyperparameter
+  space is a natural upgrade).
+- **Composite score stability across dimension sampling.** If we sample
+  `d ∈ {2, 5, 10}` we need to *stratify* (same mix of dimensions on both
+  sides of the comparison) or the score will be dominated by whichever
+  dimension happened to be sampled more.
+- **Coordination with `simplify`, `review`, `security-review`.** The loop
+  should not run alongside a human PR — race conditions on the branch
+  would be ugly. A simple lockfile suffices.
+
+## 11. Success criteria
+
+After Phase 5, the framework is "self-improving" when:
+
+- A loop run of 50 iterations on hyperparameters produces a composite-score
+  improvement of ≥ `0.02` on the standard battery, validated against a
+  held-out random seed.
+- The improvement is *retained* when re-measured a week later on fresh
+  samples.
+- No regression worse than `−0.02` on any individual pair.
+- Total human intervention: approving the PR that merges the accepted
+  ladder.
+
+That is the target.


### PR DESCRIPTION
## Summary

Document the `composite_score` as the single number that judges Panobbgo's
efficiency, and lay out the design for an autonomous improvement loop that
runs against a **parametrically-randomized** problem battery.

The vision driving this PR: run Panobbgo in a `measure → propose → apply →
measure → accept/revert` loop against standardized-but-randomized tests,
so a sustained positive trend in the score means the framework really got
better, not that it overfit to fixed instances.

### What changed

**Documentation**
- `doc/source/guide_benchmarking.rst` — new Sphinx guide with the exact
  composite-score formula, interpretation table, reproducibility model,
  `compare` workflow, statistical caveats, and pointers to planned
  parametric randomization + external baselines.
- `doc/source/guide.rst` — toctree wired up.
- `panobbgo/harness.py`, `benchmark_harness.py` — richer module docstrings,
  explicit per-run solve-fraction formula `s = 1 - (k* - 1)/B`, stability
  contract for the formula, cross-links to the guide and plan.
- `AGENTS.md` — expanded Benchmark Harness section with a statistical-rigor
  subsection and a "composite score formula is a stable contract" note.

**Plan**
- `planning/SELF_IMPROVEMENT_LOOP.md` — new design document covering:
  - Gap analysis of today's harness.
  - Parametric problem battery (translate, rotate, scale, noise, dim).
  - External absolute baselines (`scipy.optimize.differential_evolution`,
    `dual_annealing`, `pycma`, random search) so we can say how Panobbgo
    compares in absolute terms.
  - Bootstrap-CI-based statistical acceptance rule + anti-cherry-pick
    guard (re-measure the ladder on a fresh seed every K iterations).
  - Safety rails (dedicated branch, atomic commits, test gating, STOP
    sentinel).
  - Six-phase rollout: Phase 0 (this PR) → Phase 5 (MVP loop driver).

**Bookkeeping**
- `TODO.md` — recorded this work and the phased follow-up tasks.

### No code behaviour changes

This PR is documentation + planning only. No strategy, heuristic, or
harness logic is touched, so benchmark scores are unchanged by definition.

## Test plan

- [ ] `uv run pytest tests/test_harness.py` still passes (no code touched,
      but confirm locally).
- [ ] `make -C doc html` builds cleanly and the new `guide_benchmarking`
      page appears in the toctree.
- [ ] Spot-check that `benchmark_harness.py --help` and `run --help`
      still render (only the module docstring was updated).
- [ ] Reviewer confirms the composite-score formula in
      `guide_benchmarking.rst` matches
      `ProblemStrategyResult.compute_metrics` in `panobbgo/harness.py`.

https://claude.ai/code/session_013DeQUtoot1RqJ83qCJGADi