### PR TITLE
Add statistical CI testing to benchmark comparisons

### DIFF
--- a/benchmark_harness.py
+++ b/benchmark_harness.py
@@ -210,6 +210,7 @@ def cmd_compare(args: argparse.Namespace) -> int:
         eps=args.eps,
         label_before=args.before,
         label_after=args.after,
+        statistical=args.statistical,
     )
     comparison.print_summary()
 
@@ -236,6 +237,22 @@ def cmd_compare(args: argparse.Namespace) -> int:
                 for p, s, sc in comparison.only_after
             ],
         }
+
+        if comparison.statistical:
+            out["statistical"] = {
+                "accepted": comparison.accepted,
+                "ci_lower": comparison.ci_lower,
+                "ci_upper": comparison.ci_upper,
+                "pair_cis": [
+                    {
+                        "problem": p,
+                        "strategy": s,
+                        "ci_lower": l,
+                        "ci_upper": u
+                    }
+                    for (p, s), (l, u) in comparison.pair_cis.items()
+                ]
+            }
         print(json.dumps(out, indent=2))
 
     # Non-zero exit if candidate is strictly worse (useful for CI gating)
@@ -375,6 +392,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     cmp_p.add_argument(
         "--json", action="store_true", help="Also print machine-readable JSON diff"
+    )
+    cmp_p.add_argument(
+        "--statistical",
+        action="store_true",
+        help="Use statistical acceptance rule (Bootstrap CI) for comparison"
     )
     cmp_p.set_defaults(func=cmd_compare)
 

--- a/doc/source/guide.rst
+++ b/doc/source/guide.rst
@@ -40,6 +40,8 @@ Quick Navigation
      - Check :doc:`guide_extending` for adding custom heuristics, analyzers, and problems
    * - **Interested in research?**
      - Explore :doc:`guide_research` for related work, theoretical properties, and future directions
+   * - **Want to measure progress statistically?**
+     - Read :doc:`guide_benchmarking` for composite scores and bootstrap CI comparisons
    * - **Want to measure progress?**
      - Read :doc:`guide_benchmarking` for the composite score, external baselines, and the self-improvement loop
 

--- a/panobbgo/harness.py
+++ b/panobbgo/harness.py
@@ -918,6 +918,13 @@ class ComparisonResult:
     only_before: List[Tuple[str, str, float]] = field(default_factory=list)
     only_after: List[Tuple[str, str, float]] = field(default_factory=list)
 
+    # Statistical test outputs (if requested)
+    statistical: bool = False
+    ci_lower: Optional[float] = None
+    ci_upper: Optional[float] = None
+    pair_cis: Dict[Tuple[str, str], Tuple[float, float]] = field(default_factory=dict)
+    accepted: Optional[bool] = None
+
     def print_summary(self, width: int = 72) -> None:
         """Print a formatted comparison to stdout."""
         bar = "=" * width
@@ -954,6 +961,22 @@ class ComparisonResult:
                 f"  Only in candidate ({len(self.only_after)}): "
                 + ", ".join(f"{p}/{s}" for p, s, _ in self.only_after)
             )
+
+        if self.statistical:
+            print(bar)
+            print("  STATISTICAL ACCEPTANCE (95% Bootstrap CI)")
+            if self.ci_lower is not None and self.ci_upper is not None:
+                print(f"  Overall CI:    [{self.ci_lower:+.4f}, {self.ci_upper:+.4f}]")
+            else:
+                print("  Overall CI:    N/A (No matching pairs)")
+            print(f"  Decision:      {'✅ ACCEPT' if self.accepted else '❌ REJECT'}")
+
+            if self.pair_cis:
+                print(f"  Per-pair CIs ({len(self.pair_cis)}):")
+                for key, (ci_l, ci_u) in sorted(self.pair_cis.items()):
+                    p, s = key
+                    print(f"    {p} / {s}: [{ci_l:+.3f}, {ci_u:+.3f}]")
+
         print(bar)
 
 
@@ -963,6 +986,9 @@ def compare(
     eps: float = 0.01,
     label_before: str = "before",
     label_after: str = "after",
+    statistical: bool = False,
+    eps_accept: float = 0.005,
+    eps_regress: float = -0.05,
 ) -> ComparisonResult:
     """
     Compare two :class:`HarnessResult` objects and identify regressions /
@@ -1019,6 +1045,86 @@ def compare(
         else float("inf")
     )
 
+    ci_lower = None
+    ci_upper = None
+    pair_cis = {}
+    accepted = None
+
+    if statistical:
+        # We need the per-run solve fractions for all matched pairs.
+        # This requires matching the problem/strategy results.
+
+        # Helper: Extract all run solve fractions for a PSR
+        def get_fractions(psr):
+            fracs = []
+            for run in psr.runs:
+                if run.first_success_eval is not None:
+                    f = 1.0 - (run.first_success_eval - 1) / max(1, psr.budget)
+                    fracs.append(max(0.0, min(1.0, f)))
+                else:
+                    fracs.append(0.0)
+            return np.array(fracs)
+
+        before_psrs = {(psr.problem_name, psr.strategy_name): psr for psr in before.problem_strategy_results}
+        after_psrs = {(psr.problem_name, psr.strategy_name): psr for psr in after.problem_strategy_results}
+
+        all_diffs = []
+        pair_min_diff = float("inf")
+
+        rng = np.random.default_rng(42)
+        n_resamples = 10000
+        alpha = 0.05
+
+        for key in both_keys:
+            b_psr = before_psrs[key]
+            a_psr = after_psrs[key]
+
+            # Note: We assume len(b_psr.runs) == len(a_psr.runs)
+            b_fracs = get_fractions(b_psr)
+            a_fracs = get_fractions(a_psr)
+
+            # Pad with nan or truncate to match length if they differ, though they shouldn't
+            min_len = min(len(b_fracs), len(a_fracs))
+            b_fracs = b_fracs[:min_len]
+            a_fracs = a_fracs[:min_len]
+
+            diffs = a_fracs - b_fracs
+            all_diffs.extend(diffs)
+
+            # Pair-level bootstrap CI
+            means = []
+            for _ in range(n_resamples):
+                resample = rng.choice(diffs, size=len(diffs), replace=True)
+                means.append(np.mean(resample))
+
+            p_lower = float(np.percentile(means, 100 * (alpha / 2)))
+            p_upper = float(np.percentile(means, 100 * (1 - alpha / 2)))
+            pair_cis[key] = (p_lower, p_upper)
+
+            # We care about the actual mean difference for the acceptance rule minimum
+            pair_mean_diff = float(np.mean(diffs))
+            if pair_mean_diff < pair_min_diff:
+                pair_min_diff = pair_mean_diff
+
+        # Overall bootstrap CI over all paired runs
+        if all_diffs:
+            all_diffs_arr = np.array(all_diffs)
+            means = []
+            for _ in range(n_resamples):
+                resample = rng.choice(all_diffs_arr, size=len(all_diffs_arr), replace=True)
+                means.append(np.mean(resample))
+
+            ci_lower = float(np.percentile(means, 100 * (alpha / 2)))
+            ci_upper = float(np.percentile(means, 100 * (1 - alpha / 2)))
+
+            # Statistical acceptance rule:
+            # 1. Delta > eps_accept
+            # 2. Lower bound of bootstrap 95% CI > 0
+            # 3. No pair regresses more than eps_regress
+            accepted = (delta > eps_accept) and (ci_lower > 0) and (pair_min_diff > eps_regress)
+        else:
+            accepted = False
+
     return ComparisonResult(
         before=label_before,
         after=label_after,
@@ -1031,6 +1137,11 @@ def compare(
         unchanged=unchanged,
         only_before=only_before,
         only_after=only_after,
+        statistical=statistical,
+        ci_lower=ci_lower,
+        ci_upper=ci_upper,
+        pair_cis=pair_cis,
+        accepted=accepted,
     )
 
 

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -886,3 +886,30 @@ class TestCLI:
             ]
         )
         assert ret == 1
+
+
+def test_statistical_compare(tmp_path):
+    from benchmark_harness import main
+    from panobbgo.harness import BenchmarkHarness, HarnessConfig
+
+    def run_and_save(fname: str, seed: int) -> str:
+        config = HarnessConfig(
+            mode="quick",
+            problems=["DeJong_2D"],
+            strategies=["RoundRobin_Random"],
+            budget=20,
+            reps=3,
+            seed=seed,
+            timeout_per_run=60.0,
+        )
+        result = BenchmarkHarness(config).run(verbose=False)
+        path = str(tmp_path / fname)
+        result.save(path)
+        return path
+
+    before = run_and_save("before.json", 10)
+    after = run_and_save("after.json", 42)
+
+    # Run compare with statistical flag
+    ret = main(["compare", before, after, "--statistical"])
+    assert ret in (0, 2)


### PR DESCRIPTION
Adds statistical acceptance rule testing via Bootstrap CIs to the benchmark harness, enabling automated validation of parameter or algorithmic improvements as requested in the task prompt.

---
*PR created automatically by Jules for task [5925591496240115347](https://jules.google.com/task/5925591496240115347) started by @haraldschilly*