### PR TITLE
feat(self_improve): anti-cherry-pick guard (§6.3) + tests for Phase 5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,7 +202,29 @@ The harness is the measurement substrate for an autonomous
     **shipped**, see `--baselines` and `panobbgo/harness_baselines.py`.
 *   Statistical acceptance rules (bootstrap CI on score delta) —
     **shipped**, see `--statistical` and `panobbgo.harness.statistical_accept`.
-*   Loop driver — **pending** (Phase 5).
+*   Loop driver — **shipped** (Phase 5), see `panobbgo/self_improve.py`
+    and `scripts/self_improve.py` (`run` / `summary` subcommands).
+*   Anti-cherry-pick guard — **shipped** (Phase 6.3), see
+    `LoopConfig.guard_interval` / `guard_eps_ladder` /
+    `guard_iteration_offset` and the `--guard-interval`,
+    `--guard-eps-ladder`, `--guard-iteration-offset` CLI flags.  The
+    guard periodically re-measures the top of the accepted ladder on
+    a fresh randomized seed and rolls back if the composite drifts
+    below tolerance, catching instance cherry-picking.
+
+Run the loop:
+
+```bash
+# 5 quick iterations
+uv run python scripts/self_improve.py run --iterations 5
+
+# Long run with the anti-cherry-pick guard every 10 iterations
+uv run python scripts/self_improve.py run --iterations 100 \
+    --mode standard --guard-interval 10 --guard-eps-ladder 0.02
+
+# Inspect the ledger
+uv run python scripts/self_improve.py summary
+```
 
 ## CI/CD and Testing
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,59 @@
 
 ## Recent Improvements
 
+### Anti-Cherry-Pick Guard for Self-Improvement Loop (Phase 6.3) (2026-04-26)
+- [x] **New `LoopConfig.guard_interval` / `guard_eps_ladder` /
+      `guard_iteration_offset`** in `panobbgo/self_improve.py` —
+      implements §6.3 of `planning/SELF_IMPROVEMENT_LOOP.md`.  Every
+      ``guard_interval`` iterations the loop re-measures the top of
+      the accepted ladder on a *fresh* randomized seed and rolls back
+      if the composite drifts more than ``guard_eps_ladder`` below the
+      stored ``last_validated_score``.  The seed entry is the trusted
+      fallback and is never popped.
+  - **Why this matters.**  Even with the parametrically randomized
+    battery, a sequence of "lucky" instance draws can inflate
+    per-iteration ``after`` scores enough to clear the bootstrap CI.
+    The guard catches this drift by validating the ladder against an
+    independent instance stream (``randomize_iteration = iteration +
+    guard_iteration_offset``).
+  - **Disabled by default** (``guard_interval = 0``) for backward
+    compatibility; bump to ``5`` or ``10`` for unattended runs.
+- [x] **New `LadderEntry` and `LoopGuardRecord` types** —
+      `LadderEntry` snapshots ``(iteration, specs,
+      last_validated_score, proposal)``; `LoopGuardRecord` records the
+      outcome of one guard check and is written to the same JSONL
+      ledger with ``record_type = "guard"``.  `LoopIterationRecord`
+      gains ``record_type = "iteration"`` for symmetry.
+- [x] **CLI flags** `--guard-interval`, `--guard-eps-ladder`,
+      `--guard-iteration-offset` on `scripts/self_improve.py run`;
+      `summary` now distinguishes iteration and guard records and
+      prints rollback details.
+- [x] **40 tests in `tests/test_self_improve.py`** — comprehensive
+      coverage of `MutationRule` validation, `MutationCatalog` sampling
+      (log-uniform / integer-add / float-uniform), `apply_mutation`
+      immutability, `LoopConfig` validation, end-to-end
+      `SelfImprover` runs with a faked harness (zero iterations, skip,
+      accept, reject, STOP sentinel), the new guard
+      (cadence, no-rollback when stable, rollback on drift, offset
+      iteration id, seed not popped), ledger round-trip, and dataclass
+      serialisation.  Phase 5 shipped without tests; this PR fills
+      that gap as well.
+- [x] **Documentation updated**
+  - `planning/SELF_IMPROVEMENT_LOOP.md`: §6.3 marked shipped, §2
+    "what's missing" list updated, Phase 5 / Phase 6 checklists
+    refreshed, new §12 "Next iteration ideas" with Adaptive Mutation
+    Sampler, Stratified Dimension Sampling, Strategy Portfolio
+    Composition, and Hold-out Validation Set as carry-over tickets.
+  - `doc/source/guide_benchmarking.rst`: new "Anti-cherry-pick guard
+    (§6.3)" subsection with algorithm, programmatic example, and
+    safety-rail rationale.
+  - `doc/source/guide.rst`: quick-nav entry mentions the loop driver
+    and guard.
+  - `AGENTS.md`: self-improvement loop subsection now lists the loop
+    driver (shipped) and the guard (shipped) with run-the-loop bash
+    examples.
+  - This TODO entry.
+
 ### Parametrically Randomized Problem Battery (Self-Improvement Loop Phase 3) (2026-04-22)
 - [x] **New `panobbgo/harness_randomized.py`** — Phase 3 of the
       self-improvement loop: the fixed harness battery is replaced with a

--- a/doc/source/guide.rst
+++ b/doc/source/guide.rst
@@ -41,7 +41,7 @@ Quick Navigation
    * - **Interested in research?**
      - Explore :doc:`guide_research` for related work, theoretical properties, and future directions
    * - **Want to measure progress?**
-     - Read :doc:`guide_benchmarking` for the composite score, external baselines, parametrically randomised problems, the statistical acceptance rule, and the self-improvement loop
+     - Read :doc:`guide_benchmarking` for the composite score, external baselines, parametrically randomised problems, the statistical acceptance rule, the autonomous self-improvement loop driver, and the anti-cherry-pick guard
 
 Guide Contents
 --------------

--- a/doc/source/guide_benchmarking.rst
+++ b/doc/source/guide_benchmarking.rst
@@ -462,6 +462,71 @@ improvement loop:
 Design and phased roadmap: ``planning/SELF_IMPROVEMENT_LOOP.md`` in the
 repository.
 
+The MVP driver is shipped as :mod:`panobbgo.self_improve` plus the
+``scripts/self_improve.py`` CLI:
+
+.. code-block:: bash
+
+   # 5 quick iterations, randomized battery, ledger at the default path
+   uv run python scripts/self_improve.py run --iterations 5
+
+   # Long unattended run with the anti-cherry-pick guard every 10 iters
+   uv run python scripts/self_improve.py run --mode standard \
+       --iterations 100 --guard-interval 10 --guard-eps-ladder 0.02
+
+   # Pretty-print a previous ledger (counts accepts, guards, rollbacks)
+   uv run python scripts/self_improve.py summary
+
+Anti-cherry-pick guard (§6.3)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Even with the parametrically randomized battery, a sequence of "lucky"
+instance draws can inflate per-iteration ``after`` scores enough to
+clear the bootstrap CI.  The **anti-cherry-pick guard** mitigates this
+by periodically re-measuring the *top of the accepted ladder* on a
+fresh randomized seed and rolling the ladder back if the score has
+drifted.
+
+Algorithm:
+
+1. Maintain a ladder of accepted spec lists: an entry stores the
+   iteration that produced it, the spec snapshot, and the
+   ``last_validated_score`` (the composite that originally got it
+   promoted, refreshed every time the guard validates the entry).
+2. Every :attr:`~panobbgo.self_improve.LoopConfig.guard_interval`
+   iterations, re-measure the top entry on
+   ``randomize_iteration = iteration + guard_iteration_offset`` (a
+   large offset, ``1_000_000`` by default, keeps the guard's instance
+   stream independent from the regular iteration stream).
+3. If the re-measured composite is below the stored
+   ``last_validated_score`` by more than
+   :attr:`~panobbgo.self_improve.LoopConfig.guard_eps_ladder`, pop the
+   entry and re-measure the next one down — repeat until a stable
+   entry is found or the seed is reached.  The seed entry is **never**
+   popped: it is the trusted fallback by definition.
+4. Each guard check writes a
+   :class:`~panobbgo.self_improve.LoopGuardRecord` to the ledger
+   (``record_type = "guard"``) so audits can replay both signals.
+
+The guard is **disabled by default** (``guard_interval = 0``) for
+backward compatibility.  Bump it to ``5`` or ``10`` for unattended
+multi-hour runs where instance cherry-picking is the dominant
+risk.
+
+Programmatic use:
+
+.. code-block:: python
+
+   from panobbgo.self_improve import LoopConfig, SelfImprover
+
+   cfg = LoopConfig(
+       iterations=50,
+       mode="standard",
+       guard_interval=10,
+       guard_eps_ladder=0.02,
+   )
+   iter_records, guard_records = SelfImprover(cfg).run_with_guard_records()
+
 
 Extending the harness
 ---------------------

--- a/panobbgo/self_improve.py
+++ b/panobbgo/self_improve.py
@@ -58,6 +58,21 @@ The mutation sampler uses its own seeded RNG
 A loop of ``N`` iterations is fully replayable from
 ``(base_seed, mutation_seed, stat_seed)``.
 
+Anti-cherry-pick guard (§6.3)
+-----------------------------
+
+Even with a randomized battery, a sequence of "lucky" instance draws can
+inflate per-iteration ``after`` scores enough to clear the bootstrap CI.
+The guard mitigates this by periodically re-measuring the **top of the
+accepted ladder** on a *fresh* iteration seed (``iteration +
+guard_iteration_offset``).  If the re-measured composite drops more than
+``guard_eps_ladder`` below the score that originally got it accepted, the
+loop pops that ladder entry and retries with the previous one — until a
+stable entry is found or the seed strategies are reached.  Set
+``LoopConfig.guard_interval`` to a positive integer (typically ``5`` or
+``10``) to enable; ``0`` (default) disables the guard so existing
+configurations behave identically.
+
 Safety rails (§8 in the plan)
 -----------------------------
 
@@ -72,6 +87,8 @@ Safety rails (§8 in the plan)
 * **Bounded perturbations** — every mutation rule declares ``bounds`` so
   the search cannot run away (e.g., ``Nearby.radius`` stays in
   ``[0.005, 0.5]``).
+* **Anti-cherry-pick** — the periodic guard described above catches
+  drifts caused by accidental instance cherry-picking.
 
 See also
 --------
@@ -88,7 +105,7 @@ from __future__ import annotations
 import json
 import pathlib
 import time
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
@@ -483,6 +500,24 @@ class LoopConfig:
         randomize: If ``True`` (default), the randomized problem battery
             is used so instances vary by iteration.  Set to ``False`` to
             run against the fixed modes (useful for debugging).
+        guard_interval: How often (in completed iterations) to run the
+            anti-cherry-pick guard from §6.3 of the plan.  ``0`` (default)
+            disables the guard.  A positive value, typically ``5`` or
+            ``10``, instructs the loop to re-measure the top of the
+            accepted ladder on a *fresh* seed every ``guard_interval``
+            iterations and roll the ladder back if the re-measurement
+            drops more than :attr:`guard_eps_ladder` below the score that
+            originally got the entry accepted.
+        guard_eps_ladder: Tolerance for ladder drift detected by the
+            guard.  If the re-measured composite is lower than the
+            stored ``last_validated_score`` by more than this amount,
+            the entry is rolled back.  Default ``0.02`` follows the plan.
+        guard_iteration_offset: Offset added to the regular iteration id
+            when deriving the guard's randomized seed.  Picking a large
+            constant (default ``1_000_000``) keeps the guard's instance
+            stream independent from the regular iteration stream so a
+            mutation cannot accidentally tune itself to the guard's
+            seeds.
     """
 
     iterations: int = 5
@@ -501,12 +536,19 @@ class LoopConfig:
     stop_sentinel_path: str = "STOP_SELF_IMPROVE"
     timeout_per_run: Optional[float] = 120.0
     randomize: bool = True
+    guard_interval: int = 0
+    guard_eps_ladder: float = 0.02
+    guard_iteration_offset: int = 1_000_000
 
     def __post_init__(self) -> None:
         if self.iterations < 0:
             raise ValueError(f"iterations must be >= 0, got {self.iterations}")
         if self.mode not in {"quick", "standard", "full"}:
             raise ValueError(f"Unknown mode {self.mode!r}")
+        if self.guard_interval < 0:
+            raise ValueError(f"guard_interval must be >= 0, got {self.guard_interval}")
+        if self.guard_eps_ladder < 0:
+            raise ValueError(f"guard_eps_ladder must be >= 0, got {self.guard_eps_ladder}")
 
     def harness_config(
         self,
@@ -548,9 +590,11 @@ class LoopIterationRecord:
     randomize_iteration: int = 0
     mode: str = "quick"
     reason_skipped: Optional[str] = None
+    record_type: str = "iteration"
 
     def to_dict(self) -> Dict[str, Any]:
         d: Dict[str, Any] = {
+            "record_type": self.record_type,
             "iteration": self.iteration,
             "timestamp": self.timestamp,
             "duration_seconds": self.duration_seconds,
@@ -570,6 +614,112 @@ class LoopIterationRecord:
             "reason_skipped": self.reason_skipped,
         }
         return d
+
+
+@dataclass
+class LadderEntry:
+    """An entry in the accepted-mutation ladder maintained by :class:`SelfImprover`.
+
+    The ladder is the running record of strategy spec lists the loop has
+    promoted.  Entry ``-1`` is the seed (the spec list the loop started
+    with); subsequent entries record each accepted mutation.  The
+    anti-cherry-pick guard from §6.3 of the plan operates on this list:
+    it re-measures the top entry on a fresh randomized seed and pops it
+    if the score has drifted below :attr:`last_validated_score` by more
+    than :attr:`LoopConfig.guard_eps_ladder`.
+
+    Attributes:
+        iteration: Iteration index that produced this entry, or ``-1``
+            for the seed.
+        specs: The :class:`StrategySpec` list snapshot.
+        last_validated_score: The composite score most recently observed
+            for this entry.  Refreshed each time the guard validates the
+            entry, so it tracks the *current* expected performance, not
+            just the historical one.
+        proposal: The mutation that produced this entry, or ``None`` for
+            the seed.  Used for ledger output.
+    """
+
+    iteration: int
+    specs: List[StrategySpec]
+    last_validated_score: float
+    proposal: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class LoopGuardRecord:
+    """One ledger line — outcome of a single anti-cherry-pick guard check.
+
+    The guard is invoked every :attr:`LoopConfig.guard_interval`
+    iterations.  It re-measures the top of the ladder on a *fresh* seed
+    (``iteration + LoopConfig.guard_iteration_offset``) and rolls the
+    ladder back if the re-measured score has drifted too far below the
+    stored :attr:`LadderEntry.last_validated_score`.
+
+    Attributes:
+        iteration: Iteration index after which the guard ran (the
+            iteration that *triggered* it).
+        timestamp: ISO-8601 UTC timestamp.
+        duration_seconds: Wall-clock cost of the guard, including any
+            re-measurements performed during rollback.
+        guard_score: Re-measured composite score for the top entry of
+            the ladder before any rollback.
+        pre_guard_top_score: ``last_validated_score`` of the top entry
+            before the guard ran.
+        pre_guard_top_iteration: ``iteration`` of the top entry before
+            the guard ran (``-1`` for the seed).
+        rolled_back: Whether the guard popped at least one ladder entry.
+        rolled_back_to_iteration: Iteration index of the new top after
+            rollback (``-1`` for the seed), or ``None`` if no rollback
+            happened.
+        pops: Number of ladder entries popped during rollback.
+        ladder_size_before: Length of the ladder before the guard.
+        ladder_size_after: Length of the ladder after the guard.
+        guard_iteration_id: ``randomize_iteration`` used by the harness
+            for the guard re-measurement (i.e. the "fresh" seed).
+        reasons: Human-readable bullet points.
+        base_seed: Loop's base seed (for ledger search).
+        mode: Harness mode used for the guard.
+        record_type: Always ``"guard"``; lets ledger consumers
+            distinguish guard records from regular iteration records.
+    """
+
+    iteration: int
+    timestamp: str
+    duration_seconds: float
+    guard_score: float
+    pre_guard_top_score: float
+    pre_guard_top_iteration: int
+    rolled_back: bool
+    rolled_back_to_iteration: Optional[int]
+    pops: int
+    ladder_size_before: int
+    ladder_size_after: int
+    guard_iteration_id: int
+    reasons: List[str] = field(default_factory=list)
+    base_seed: int = 42
+    mode: str = "quick"
+    record_type: str = "guard"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "record_type": self.record_type,
+            "iteration": self.iteration,
+            "timestamp": self.timestamp,
+            "duration_seconds": self.duration_seconds,
+            "guard_score": self.guard_score,
+            "pre_guard_top_score": self.pre_guard_top_score,
+            "pre_guard_top_iteration": self.pre_guard_top_iteration,
+            "rolled_back": self.rolled_back,
+            "rolled_back_to_iteration": self.rolled_back_to_iteration,
+            "pops": self.pops,
+            "ladder_size_before": self.ladder_size_before,
+            "ladder_size_after": self.ladder_size_after,
+            "guard_iteration_id": self.guard_iteration_id,
+            "reasons": list(self.reasons),
+            "base_seed": self.base_seed,
+            "mode": self.mode,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -615,10 +765,34 @@ class SelfImprover:
     # ------------------------------------------------------------------
 
     def run(self, verbose: bool = False) -> List[LoopIterationRecord]:
-        """Run the loop and return the per-iteration records."""
+        """Run the loop and return the per-iteration records.
+
+        Guard records (:class:`LoopGuardRecord`) are written to the
+        ledger alongside iteration records but are not returned here —
+        the contract of :meth:`run` is unchanged for backward
+        compatibility.  Use :meth:`run_with_guard_records` when both
+        are wanted in-process, or read the ledger to recover them.
+        """
+        records, _ = self._run_internal(verbose=verbose)
+        return records
+
+    def run_with_guard_records(self, verbose: bool = False) -> Tuple[List[LoopIterationRecord], List[LoopGuardRecord]]:
+        """Run the loop and return ``(iteration_records, guard_records)``.
+
+        The two lists are returned separately so existing callers of
+        :meth:`run` keep their type contract.  Both lists are also
+        persisted to the ledger.
+        """
+        return self._run_internal(verbose=verbose)
+
+    def _run_internal(self, verbose: bool = False) -> Tuple[List[LoopIterationRecord], List[LoopGuardRecord]]:
         current = self._load_seed_strategies()
         rng = np.random.default_rng(self.config.mutation_seed)
         records: List[LoopIterationRecord] = []
+        guard_records: List[LoopGuardRecord] = []
+        ladder: List[LadderEntry] = [
+            LadderEntry(iteration=-1, specs=list(current), last_validated_score=float("nan"), proposal=None)
+        ]
         ledger = _LedgerWriter(self.config.ledger_path)
 
         for iteration in range(self.config.iterations):
@@ -639,6 +813,15 @@ class SelfImprover:
                 ledger.write(rec)
                 if verbose:
                     self._print_iteration(rec)
+                # Guard still runs on skip iterations — it validates the
+                # ladder, which is independent of whether this iteration
+                # produced a proposal.
+                if self._guard_due(iteration):
+                    guard_record = self._run_guard(ladder, iteration, verbose)
+                    guard_records.append(guard_record)
+                    ledger.write(guard_record)
+                    if guard_record.rolled_back:
+                        current = list(ladder[-1].specs)
                 continue
 
             candidate = apply_mutation(current, proposal)
@@ -668,7 +851,11 @@ class SelfImprover:
                 ci_low=float(decision.ci_low),
                 ci_high=float(decision.ci_high),
                 worst_pair_regression=float(decision.worst_pair_regression),
-                worst_pair=(tuple(decision.worst_pair) if decision.worst_pair is not None else None),
+                worst_pair=(
+                    (str(decision.worst_pair[0]), str(decision.worst_pair[1]))
+                    if decision.worst_pair is not None
+                    else None
+                ),
                 reasons=list(decision.reasons),
                 base_seed=self.config.base_seed,
                 randomize_iteration=iteration,
@@ -679,10 +866,34 @@ class SelfImprover:
             if verbose:
                 self._print_iteration(rec)
 
+            # Refresh the seed entry's validated score the first time we
+            # measure with it so the guard has a baseline to compare
+            # against (the seed itself never gets accepted, but it can
+            # still be the rollback target).
+            if np.isnan(ladder[0].last_validated_score):
+                ladder[0].last_validated_score = float(baseline_result.composite_score)
+
             if decision.accept:
                 current = candidate
+                ladder.append(
+                    LadderEntry(
+                        iteration=iteration,
+                        specs=list(candidate),
+                        last_validated_score=float(candidate_result.composite_score),
+                        proposal=proposal.to_dict(),
+                    )
+                )
 
-        return records
+            # Anti-cherry-pick guard (§6.3 of the plan).  Run after the
+            # iteration so a freshly accepted entry can be challenged.
+            if self._guard_due(iteration):
+                guard_record = self._run_guard(ladder, iteration, verbose)
+                guard_records.append(guard_record)
+                ledger.write(guard_record)
+                if guard_record.rolled_back:
+                    current = list(ladder[-1].specs)
+
+        return records, guard_records
 
     # ------------------------------------------------------------------
     # Helpers
@@ -732,6 +943,135 @@ class SelfImprover:
             return False
         return pathlib.Path(self.config.stop_sentinel_path).exists()
 
+    def _guard_due(self, iteration: int) -> bool:
+        """Return True if the guard should run after this iteration."""
+        if self.config.guard_interval <= 0:
+            return False
+        # Run on every multiple of guard_interval (1-indexed): after
+        # iteration 0 if interval == 1, after iteration K-1 if K > 1, etc.
+        return ((iteration + 1) % self.config.guard_interval) == 0
+
+    def _guard_iteration_id(self, iteration: int) -> int:
+        """Translate a regular iteration index into the guard's seed.
+
+        We add a large offset rather than reuse the regular iteration
+        stream so the guard's instances are independent — this prevents
+        a mutation from accidentally tuning itself to the seeds the
+        guard would reuse.
+        """
+        return int(iteration) + int(self.config.guard_iteration_offset)
+
+    def _run_guard(
+        self,
+        ladder: List["LadderEntry"],
+        iteration: int,
+        verbose: bool,
+    ) -> "LoopGuardRecord":
+        """Re-measure the top of the ladder on a fresh seed; roll back if drifted.
+
+        Implements §6.3 of ``planning/SELF_IMPROVEMENT_LOOP.md``.  The
+        method is deliberately simple: it walks down the ladder one
+        entry at a time, re-measuring each on the same fresh
+        ``randomize_iteration`` seed, and stops at the first entry whose
+        score is within :attr:`LoopConfig.guard_eps_ladder` of its
+        stored ``last_validated_score``.  If the seed entry is reached,
+        no further pops happen — the seed strategies are by definition
+        the safe fallback.
+        """
+        start = time.time()
+        guard_iter_id = self._guard_iteration_id(iteration)
+        size_before = len(ladder)
+        reasons: List[str] = []
+
+        # Re-measure the current top.
+        top = ladder[-1]
+        top_result = self._measure(top.specs, guard_iter_id, "guard", verbose)
+        guard_score = float(top_result.composite_score)
+        pre_guard_top_score = float(top.last_validated_score)
+        pre_guard_top_iteration = int(top.iteration)
+
+        # Within tolerance?  Refresh the validated score and return.
+        if not self._guard_drifted(guard_score, pre_guard_top_score):
+            top.last_validated_score = guard_score
+            reasons.append(
+                f"guard re-measure score {guard_score:.4f} within tolerance of "
+                f"{pre_guard_top_score:.4f} (eps_ladder={self.config.guard_eps_ladder:.4f})"
+            )
+            return LoopGuardRecord(
+                iteration=iteration,
+                timestamp=datetime.now(tz=timezone.utc).isoformat(),
+                duration_seconds=time.time() - start,
+                guard_score=guard_score,
+                pre_guard_top_score=pre_guard_top_score,
+                pre_guard_top_iteration=pre_guard_top_iteration,
+                rolled_back=False,
+                rolled_back_to_iteration=None,
+                pops=0,
+                ladder_size_before=size_before,
+                ladder_size_after=len(ladder),
+                guard_iteration_id=guard_iter_id,
+                reasons=reasons,
+                base_seed=self.config.base_seed,
+                mode=self.config.mode,
+            )
+
+        # Drift detected — pop and walk down the ladder.
+        reasons.append(
+            f"guard re-measure score {guard_score:.4f} dropped > eps_ladder "
+            f"({self.config.guard_eps_ladder:.4f}) below stored {pre_guard_top_score:.4f}"
+            f" — rolling back from iter {pre_guard_top_iteration}"
+        )
+        pops = 0
+        # Always keep the seed entry (index 0).  Pop while drift persists.
+        while len(ladder) > 1:
+            ladder.pop()
+            pops += 1
+            new_top = ladder[-1]
+            if new_top.iteration < 0 or np.isnan(new_top.last_validated_score):
+                # Reached the seed (or an entry without a stored score)
+                # — accept it without re-measurement; it is by definition
+                # the trusted fallback.
+                reasons.append(f"reached seed/anchor entry (iter={new_top.iteration}); stopping rollback")
+                break
+            new_result = self._measure(new_top.specs, guard_iter_id, "guard-rollback", verbose)
+            new_score = float(new_result.composite_score)
+            if not self._guard_drifted(new_score, float(new_top.last_validated_score)):
+                new_top.last_validated_score = new_score
+                reasons.append(
+                    f"rollback target iter={new_top.iteration} stable: "
+                    f"score {new_score:.4f} vs stored {new_top.last_validated_score:.4f}"
+                )
+                break
+            reasons.append(
+                f"rollback candidate iter={new_top.iteration} also drifted "
+                f"({new_score:.4f} vs {new_top.last_validated_score:.4f}); continuing"
+            )
+
+        return LoopGuardRecord(
+            iteration=iteration,
+            timestamp=datetime.now(tz=timezone.utc).isoformat(),
+            duration_seconds=time.time() - start,
+            guard_score=guard_score,
+            pre_guard_top_score=pre_guard_top_score,
+            pre_guard_top_iteration=pre_guard_top_iteration,
+            rolled_back=True,
+            rolled_back_to_iteration=int(ladder[-1].iteration),
+            pops=pops,
+            ladder_size_before=size_before,
+            ladder_size_after=len(ladder),
+            guard_iteration_id=guard_iter_id,
+            reasons=reasons,
+            base_seed=self.config.base_seed,
+            mode=self.config.mode,
+        )
+
+    def _guard_drifted(self, guard_score: float, stored_score: float) -> bool:
+        """Return True if ``guard_score`` is more than ``eps_ladder`` below stored."""
+        if np.isnan(stored_score):
+            # Nothing to compare against — treat as not drifted.
+            return False
+        return guard_score < stored_score - self.config.guard_eps_ladder
+
     @staticmethod
     def _print_iteration(rec: LoopIterationRecord) -> None:
         if rec.proposal is None:
@@ -753,7 +1093,11 @@ class SelfImprover:
 
 
 class _LedgerWriter:
-    """Append-only JSONL ledger.  Creates parent directories on demand."""
+    """Append-only JSONL ledger.  Creates parent directories on demand.
+
+    Writes both :class:`LoopIterationRecord` and :class:`LoopGuardRecord`
+    instances; the ``record_type`` field distinguishes them on read.
+    """
 
     def __init__(self, path: str) -> None:
         self.path = pathlib.Path(path)
@@ -761,7 +1105,7 @@ class _LedgerWriter:
         if str(parent) and not parent.exists():
             parent.mkdir(parents=True, exist_ok=True)
 
-    def write(self, record: LoopIterationRecord) -> None:
+    def write(self, record: Any) -> None:
         line = json.dumps(record.to_dict(), default=_json_default)
         with self.path.open("a", encoding="utf-8") as f:
             f.write(line + "\n")
@@ -800,6 +1144,8 @@ __all__ = [
     "apply_mutation",
     "LoopConfig",
     "LoopIterationRecord",
+    "LoopGuardRecord",
+    "LadderEntry",
     "SelfImprover",
     "load_ledger",
 ]

--- a/planning/SELF_IMPROVEMENT_LOOP.md
+++ b/planning/SELF_IMPROVEMENT_LOOP.md
@@ -58,10 +58,20 @@ What's missing for a true self-improvement loop:
       on `benchmark_harness.py compare`.  Bootstrap CI on composite
       delta + per-pair regression guard (§6.2).  Tests in
       `tests/test_harness_stats.py`.
-- [ ] A driver that closes the loop: apply change, measure, accept/revert,
-      commit.
-- [ ] A change catalog — the space of mutations the loop may try.
-- [ ] Persistence of the running "ladder" of best composite scores over time.
+- [x] Anti-cherry-pick guard (§6.3) — shipped 2026-04-26 as
+      `LoopConfig.guard_interval` / `guard_eps_ladder` /
+      `guard_iteration_offset`.  Periodic ladder re-validation on a
+      fresh seed; rollback on drift.
+- [x] A driver that closes the loop: apply change, measure,
+      accept/revert — shipped 2026-04-23 as
+      `panobbgo.self_improve.SelfImprover` and `scripts/self_improve.py`.
+- [x] A change catalog — `panobbgo.self_improve.MutationCatalog` and
+      `default_catalog()` cover hyperparameter retunes from §7.1.
+- [x] Persistence of the running "ladder" of best composite scores
+      over time — `LadderEntry` + JSONL ledger
+      (`planning/self_improve_ledger.jsonl`).  Each entry stores its
+      ``last_validated_score``, refreshed every time the guard
+      re-measures it.
 
 ## 3. Architecture of the loop
 
@@ -205,13 +215,32 @@ deltas.
 
 - **Reject** otherwise. Revert the commit.
 
-### 6.3 Anti-cherry-pick guard
+### 6.3 Anti-cherry-pick guard (shipped 2026-04-26)
 
-Every Kth iteration (default `K = 10`), re-measure the accepted ladder on
-a *fresh* random seed. If the ladder drops more than `ε_ladder` (default
-`0.02`) on that re-measurement, roll back to the last iteration whose
-fresh-seed score is still within tolerance. This catches over-fitting to
-the particular stream of sampled problems.
+- [x] Implemented as `LoopConfig.guard_interval` /
+      `guard_eps_ladder` / `guard_iteration_offset` in
+      :mod:`panobbgo.self_improve`.  Every Kth iteration the loop
+      re-measures the top of the accepted ladder on a *fresh*
+      randomized seed (``iteration_id = iteration +
+      guard_iteration_offset``).  If the re-measure drops more than
+      ``guard_eps_ladder`` below the entry's stored
+      ``last_validated_score``, the entry is popped and the next one
+      down is re-measured; popping continues until a stable entry is
+      found or the seed strategies are reached (the seed is the
+      trusted fallback and is never popped).
+- [x] CLI: `--guard-interval`, `--guard-eps-ladder`,
+      `--guard-iteration-offset` on `scripts/self_improve.py run`.
+- [x] Ledger: emits a `LoopGuardRecord` (record_type=`"guard"`)
+      alongside iteration records so audits can replay both signals.
+- [x] Defaults: ``guard_interval=0`` (disabled) for backward
+      compatibility; bump to ``5`` or ``10`` for unattended runs.
+      ``guard_eps_ladder=0.02`` matches the plan; the offset of
+      ``1_000_000`` keeps the guard's instance stream independent from
+      the regular iteration stream so a mutation cannot accidentally
+      tune itself to the seeds the guard would reuse.
+- [x] Tests: `tests/test_self_improve.py::TestAntiCherryPickGuard`
+      covers cadence, no-op-when-stable, rollback-on-drift,
+      offset-iteration-id usage, and seed-not-popped invariants.
 
 ## 7. Change catalog
 
@@ -327,18 +356,34 @@ Each phase is independently deliverable and keeps the framework usable.
 - [x] 22 tests in ``tests/test_harness_stats.py`` — accept/reject paths,
       regression guard, reproducibility, CLI integration.
 
-### Phase 5 — Loop driver MVP (~1 week)
+### Phase 5 — Loop driver MVP (shipped 2026-04-23)
 
-- `scripts/self_improve.py` implementing §3.
-- Start with a **hyperparameter-only** mutation space (§7, item 1).
-- Runs for N iterations on a dedicated branch, writes the ledger.
-- Produces a human-readable report at the end.
+- [x] `scripts/self_improve.py` implementing §3, backed by
+      :mod:`panobbgo.self_improve`.
+- [x] Hyperparameter-only mutation space (§7, item 1) via
+      :func:`default_catalog`.
+- [x] Runs for N iterations on the current spec list (in-memory),
+      writes the JSONL ledger.
+- [x] Produces a human-readable summary via
+      `scripts/self_improve.py summary`.
+- [x] Anti-cherry-pick guard (§6.3) — shipped 2026-04-26 (see §2 and
+      §6.3).
+- [x] Tests: `tests/test_self_improve.py` (40 tests covering rules,
+      catalog, mutation application, config validation, end-to-end
+      loop with a fake harness, anti-cherry-pick guard, and ledger
+      round-trip).
 
 ### Phase 6 — Production loop (ongoing)
 
-- Broaden the mutation space.
-- Connect the loop to CI (nightly run on a dedicated runner).
-- Publish the ladder in the docs.
+- [x] Anti-cherry-pick guard (§6.3) — shipped 2026-04-26.
+- [ ] Broaden the mutation space (strategy portfolio composition,
+      analyzer add/drop — §7 items 2–3).
+- [ ] Adaptive mutation sampler (§10): bias future samples toward
+      rules with positive accept history.
+- [ ] Stratified dimension sampling (§10) for cross-iteration score
+      stability.
+- [ ] Connect the loop to CI (nightly run on a dedicated runner).
+- [ ] Publish the ladder in the docs.
 
 ## 10. Open questions
 
@@ -372,3 +417,51 @@ After Phase 5, the framework is "self-improving" when:
   ladder.
 
 That is the target.
+
+## 12. Next iteration ideas
+
+Lightweight "next ticket" notes for follow-up agents.
+
+### 12.1 Adaptive mutation sampler (§10 productivity)
+
+The current :class:`MutationCatalog` samples uniformly from the
+applicable rules.  After several iterations the loop has direct
+evidence about which rules tend to produce accepts.  A simple
+Beta-Bernoulli or UCB scheme over rules — keyed by ``(class_name,
+param_name, rule_kind)`` — would bias future samples toward rules
+with positive accept history while still exploring unfamiliar ones.
+
+Suggested implementation sketch:
+
+- Track ``(n_attempts, n_accepts)`` per rule key, persisted across
+  loop runs by the ledger reader.
+- Sample via Thompson sampling on a Beta(1+n_accepts,
+  1+n_attempts-n_accepts) prior, or UCB1 on the accept rate.
+- Cold-start: zero history → uniform sampling, identical to today.
+
+### 12.2 Stratified dimension sampling (§10 stability)
+
+When a :class:`ProblemFamily` declares ``dim_choices = (2, 5, 10)``,
+the current sampler draws one dim per instance.  Across iterations
+this dilutes the composite score with a different mix of dims each
+time, so cross-iteration deltas pick up dim-mix noise.  Stratify by
+running ``ceil(reps / k)`` reps per dim and averaging — same compute,
+much lower noise.
+
+### 12.3 Strategy portfolio composition (§7.2)
+
+Today's mutations only retune existing kwargs.  Adding a heuristic to
+or removing one from a strategy is the next-most-impactful mutation
+class and is fully expressible inside :class:`StrategySpec`.  Needs:
+
+- A ``StructuralMutationRule`` subclass capable of
+  ``add_heuristic`` / ``drop_heuristic`` ops.
+- A safety check that the resulting strategy still has at least one
+  point-emitting heuristic.
+
+### 12.4 Hold-out validation set
+
+Maintain a small fixed validation set of randomized instances drawn
+from a separate ``base_seed``.  Use it (read-only) to spot-check the
+ladder once at the end of a loop run.  Cheaper than the periodic
+guard but complements it.

--- a/scripts/self_improve.py
+++ b/scripts/self_improve.py
@@ -160,6 +160,27 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="SECS",
         help="Per-run timeout in seconds (default: 120)",
     )
+    run_p.add_argument(
+        "--guard-interval",
+        dest="guard_interval",
+        type=int,
+        default=0,
+        help=("Run the anti-cherry-pick guard every N iterations (0 = disabled, default; typical values are 5 or 10)"),
+    )
+    run_p.add_argument(
+        "--guard-eps-ladder",
+        dest="guard_eps_ladder",
+        type=float,
+        default=0.02,
+        help="Tolerance for ladder drift detected by the guard (default: 0.02)",
+    )
+    run_p.add_argument(
+        "--guard-iteration-offset",
+        dest="guard_iteration_offset",
+        type=int,
+        default=1_000_000,
+        help="Iteration-id offset for the guard's fresh seed (default: 1_000_000)",
+    )
     run_p.add_argument("--quiet", "-q", action="store_true", help="Suppress per-iteration output")
     run_p.set_defaults(func=_cmd_run)
 
@@ -195,6 +216,9 @@ def _cmd_run(args: argparse.Namespace) -> int:
         stop_sentinel_path=args.stop_sentinel,
         timeout_per_run=args.timeout,
         randomize=args.randomize,
+        guard_interval=args.guard_interval,
+        guard_eps_ladder=args.guard_eps_ladder,
+        guard_iteration_offset=args.guard_iteration_offset,
     )
     records = SelfImprover(cfg).run(verbose=not args.quiet)
 
@@ -219,16 +243,22 @@ def _cmd_summary(args: argparse.Namespace) -> int:
         print(f"(empty ledger: {path})")
         return 0
 
-    n = len(records)
-    accepted = [r for r in records if r.get("accepted")]
-    skipped = [r for r in records if r.get("proposal") is None]
-    decided = [r for r in records if r.get("proposal") is not None]
+    iter_records = [r for r in records if r.get("record_type", "iteration") == "iteration"]
+    guard_records = [r for r in records if r.get("record_type") == "guard"]
+    n = len(iter_records)
+    accepted = [r for r in iter_records if r.get("accepted")]
+    skipped = [r for r in iter_records if r.get("proposal") is None]
+    decided = [r for r in iter_records if r.get("proposal") is not None]
     accept_rate = (len(accepted) / len(decided)) if decided else 0.0
     best_delta = max((r.get("delta", 0.0) for r in decided), default=0.0)
+    rolled_back = [r for r in guard_records if r.get("rolled_back")]
 
     print(f"Ledger:        {path}")
     print(f"Iterations:    {n}  (decided={len(decided)}, skipped={len(skipped)})")
     print(f"Accepts:       {len(accepted)}  ({accept_rate:.1%} of decided)")
+    if guard_records:
+        total_pops = sum(int(r.get("pops", 0)) for r in guard_records)
+        print(f"Guards:        {len(guard_records)}  (rollbacks={len(rolled_back)}, total pops={total_pops})")
     if decided:
         print(f"Best Δ seen:   {best_delta:+.4f}")
 
@@ -241,6 +271,16 @@ def _cmd_summary(args: argparse.Namespace) -> int:
                 f"{p.get('strategy_name')}/{p.get('class_name')}."
                 f"{p.get('param_name')}: "
                 f"{p.get('old_value')!r} -> {p.get('new_value')!r}"
+            )
+
+    if rolled_back:
+        print("Guard rollbacks:")
+        for r in rolled_back:
+            print(
+                f"  iter={r.get('iteration')}  pops={r.get('pops')}  "
+                f"score={r.get('guard_score'):.4f} vs stored "
+                f"{r.get('pre_guard_top_score'):.4f}; "
+                f"new top iter={r.get('rolled_back_to_iteration')}"
             )
     return 0
 

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -1,0 +1,974 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+# Copyright 2012 -- 2026 Harald Schilly <harald.schilly@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the self-improvement loop driver (:mod:`panobbgo.self_improve`).
+
+Covers:
+
+* :class:`MutationRule` validation
+* :class:`MutationCatalog` sampling and applicable-rule filtering
+* :func:`apply_mutation` correctness and immutability
+* :class:`LoopConfig` validation
+* :class:`SelfImprover` end-to-end with a faked harness
+* The anti-cherry-pick guard (§6.3 of the plan):
+
+  - Guard does not fire when ``guard_interval == 0``.
+  - Guard fires every K iterations otherwise.
+  - Guard refreshes ``last_validated_score`` when within tolerance.
+  - Guard rolls back the ladder when re-measure drifts beyond
+    ``guard_eps_ladder``.
+  - Guard cannot pop the seed (always falls back to it).
+* Ledger writing (mixed iteration + guard records) and :func:`load_ledger`.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+import numpy as np
+import pytest
+
+from panobbgo.benchmark import StrategySpec
+from panobbgo.harness import (
+    HarnessConfig,
+    HarnessResult,
+    ProblemStrategyResult,
+    RunRecord,
+)
+from panobbgo.self_improve import (
+    LadderEntry,
+    LoopConfig,
+    LoopGuardRecord,
+    LoopIterationRecord,
+    MutationCatalog,
+    MutationProposal,
+    MutationRule,
+    SelfImprover,
+    apply_mutation,
+    default_catalog,
+    load_ledger,
+)
+
+
+# ===========================================================================
+# Test fixtures: dummy heuristic / analyzer / strategy classes
+# ===========================================================================
+
+
+class _DummyHeuristicA:
+    """Fake heuristic class used as a mutation target."""
+
+    pass
+
+
+class _DummyHeuristicB:
+    """Fake heuristic class with a different name."""
+
+    pass
+
+
+class _DummyAnalyzerC:
+    """Fake analyzer class used as a mutation target."""
+
+    pass
+
+
+class _DummyStrategy:
+    """Strategy stand-in (StrategySpec only references the class object)."""
+
+    pass
+
+
+def _make_specs() -> List[StrategySpec]:
+    """Two strategies, each with a heuristic and an analyzer carrying knobs."""
+    return [
+        StrategySpec(
+            name="StratX",
+            strategy_class=_DummyStrategy,
+            heuristics=[
+                (_DummyHeuristicA, {"radius": 0.1}),
+                (_DummyHeuristicB, {"sigma0": 0.3}),
+            ],
+            analyzers=[(_DummyAnalyzerC, {"update_interval": 20})],
+        ),
+        StrategySpec(
+            name="StratY",
+            strategy_class=_DummyStrategy,
+            heuristics=[(_DummyHeuristicA, {"radius": 0.05})],
+            analyzers=[],
+        ),
+    ]
+
+
+# ===========================================================================
+# MutationRule
+# ===========================================================================
+
+
+class TestMutationRule:
+    def test_constructs_with_valid_kind(self):
+        rule = MutationRule(
+            strategy_pattern="",
+            class_name="X",
+            param_name="p",
+            kind="log_uniform_perturb",
+            bounds=(0.0, 1.0),
+        )
+        assert rule.kind == "log_uniform_perturb"
+
+    def test_unknown_kind_raises(self):
+        with pytest.raises(ValueError, match="Unknown mutation kind"):
+            MutationRule(
+                strategy_pattern="",
+                class_name="X",
+                param_name="p",
+                kind="weird",
+                bounds=(0.0, 1.0),
+            )
+
+    def test_inverted_bounds_raise(self):
+        with pytest.raises(ValueError, match="bounds not ordered"):
+            MutationRule(
+                strategy_pattern="",
+                class_name="X",
+                param_name="p",
+                kind="float_uniform",
+                bounds=(1.0, 0.0),
+            )
+
+    def test_non_positive_probability_raises(self):
+        with pytest.raises(ValueError, match="probability"):
+            MutationRule(
+                strategy_pattern="",
+                class_name="X",
+                param_name="p",
+                kind="float_uniform",
+                bounds=(0.0, 1.0),
+                probability=0.0,
+            )
+
+
+# ===========================================================================
+# MutationCatalog: sampling, applicable rules, mutation kinds
+# ===========================================================================
+
+
+class TestMutationCatalog:
+    def test_empty_catalog_raises(self):
+        with pytest.raises(ValueError):
+            MutationCatalog([])
+
+    def test_applicable_rules_filters_by_class(self):
+        rules = [
+            MutationRule(
+                strategy_pattern="",
+                class_name="_DummyHeuristicA",
+                param_name="radius",
+                kind="log_uniform_perturb",
+                bounds=(0.005, 0.5),
+            ),
+            MutationRule(
+                strategy_pattern="",
+                class_name="_DummyHeuristicB",
+                param_name="sigma0",
+                kind="log_uniform_perturb",
+                bounds=(0.05, 1.0),
+            ),
+            MutationRule(
+                strategy_pattern="",
+                class_name="DoesNotExist",
+                param_name="foo",
+                kind="float_uniform",
+                bounds=(0.0, 1.0),
+            ),
+        ]
+        cat = MutationCatalog(rules)
+        applicable = cat.applicable_rules(_make_specs())
+        names = {r.class_name for r, _ in applicable}
+        assert names == {"_DummyHeuristicA", "_DummyHeuristicB"}
+
+    def test_applicable_rules_skips_missing_kwarg(self):
+        """Rule for an existing class but a missing kwarg should be skipped."""
+        rules = [
+            MutationRule(
+                strategy_pattern="",
+                class_name="_DummyHeuristicA",
+                param_name="not_present",
+                kind="float_uniform",
+                bounds=(0.0, 1.0),
+            ),
+        ]
+        cat = MutationCatalog(rules)
+        assert cat.applicable_rules(_make_specs()) == []
+
+    def test_strategy_pattern_filters(self):
+        rules = [
+            MutationRule(
+                strategy_pattern="StratY",
+                class_name="_DummyHeuristicA",
+                param_name="radius",
+                kind="log_uniform_perturb",
+                bounds=(0.005, 0.5),
+            ),
+        ]
+        cat = MutationCatalog(rules)
+        applicable = cat.applicable_rules(_make_specs())
+        assert len(applicable) == 1
+        rule, hits = applicable[0]
+        # Only StratY should match — single hit.
+        assert len(hits) == 1
+
+    def test_sample_returns_none_when_no_applicable_rules(self):
+        rules = [
+            MutationRule(
+                strategy_pattern="",
+                class_name="DoesNotExist",
+                param_name="foo",
+                kind="float_uniform",
+                bounds=(0.0, 1.0),
+            ),
+        ]
+        cat = MutationCatalog(rules)
+        rng = np.random.default_rng(0)
+        assert cat.sample(rng, _make_specs()) is None
+
+    def test_sample_log_uniform_stays_within_bounds(self):
+        rule = MutationRule(
+            strategy_pattern="",
+            class_name="_DummyHeuristicA",
+            param_name="radius",
+            kind="log_uniform_perturb",
+            bounds=(0.005, 0.5),
+            log_step=0.5,
+        )
+        cat = MutationCatalog([rule])
+        rng = np.random.default_rng(7)
+        for _ in range(50):
+            prop = cat.sample(rng, _make_specs())
+            assert prop is not None
+            assert 0.005 <= prop.new_value <= 0.5
+
+    def test_sample_integer_add_clamps_to_bounds(self):
+        rule = MutationRule(
+            strategy_pattern="",
+            class_name="_DummyAnalyzerC",
+            param_name="update_interval",
+            kind="integer_add",
+            bounds=(5, 60),
+            delta_choices=(-100, 100),
+        )
+        cat = MutationCatalog([rule])
+        rng = np.random.default_rng(0)
+        for _ in range(20):
+            prop = cat.sample(rng, _make_specs())
+            assert prop is not None
+            assert 5 <= prop.new_value <= 60
+            assert isinstance(prop.new_value, int)
+
+    def test_sample_float_uniform(self):
+        rule = MutationRule(
+            strategy_pattern="",
+            class_name="_DummyHeuristicA",
+            param_name="radius",
+            kind="float_uniform",
+            bounds=(0.0, 1.0),
+            low=0.2,
+            high=0.4,
+        )
+        cat = MutationCatalog([rule])
+        rng = np.random.default_rng(1)
+        for _ in range(30):
+            prop = cat.sample(rng, _make_specs())
+            assert prop is not None
+            assert 0.2 <= prop.new_value <= 0.4
+
+    def test_log_uniform_requires_positive_old(self):
+        rule = MutationRule(
+            strategy_pattern="",
+            class_name="_DummyHeuristicA",
+            param_name="radius",
+            kind="log_uniform_perturb",
+            bounds=(0.0, 1.0),
+        )
+        cat = MutationCatalog([rule])
+        rng = np.random.default_rng(0)
+        bad_specs = [
+            StrategySpec(
+                name="S",
+                strategy_class=_DummyStrategy,
+                heuristics=[(_DummyHeuristicA, {"radius": 0.0})],
+            )
+        ]
+        with pytest.raises(ValueError, match="positive"):
+            cat.sample(rng, bad_specs)
+
+    def test_default_catalog_has_rules(self):
+        cat = default_catalog()
+        assert len(cat.rules) >= 5
+
+
+# ===========================================================================
+# apply_mutation
+# ===========================================================================
+
+
+class TestApplyMutation:
+    def test_applies_to_named_strategy(self):
+        specs = _make_specs()
+        proposal = MutationProposal(
+            strategy_name="StratX",
+            class_name="_DummyHeuristicA",
+            param_name="radius",
+            old_value=0.1,
+            new_value=0.2,
+            rule_kind="log_uniform_perturb",
+            rationale="test",
+        )
+        out = apply_mutation(specs, proposal)
+        # New StratX has updated radius.
+        new_x = next(s for s in out if s.name == "StratX")
+        assert new_x.heuristics[0][1]["radius"] == 0.2
+        # Other strategy untouched.
+        new_y = next(s for s in out if s.name == "StratY")
+        assert new_y.heuristics[0][1]["radius"] == 0.05
+
+    def test_input_specs_not_mutated(self):
+        specs = _make_specs()
+        original_x_radius = specs[0].heuristics[0][1]["radius"]
+        proposal = MutationProposal(
+            strategy_name="StratX",
+            class_name="_DummyHeuristicA",
+            param_name="radius",
+            old_value=0.1,
+            new_value=0.42,
+            rule_kind="log_uniform_perturb",
+            rationale="t",
+        )
+        apply_mutation(specs, proposal)
+        # Original spec object unchanged.
+        assert specs[0].heuristics[0][1]["radius"] == original_x_radius
+
+    def test_applies_to_analyzer(self):
+        specs = _make_specs()
+        proposal = MutationProposal(
+            strategy_name="StratX",
+            class_name="_DummyAnalyzerC",
+            param_name="update_interval",
+            old_value=20,
+            new_value=30,
+            rule_kind="integer_add",
+            rationale="t",
+        )
+        out = apply_mutation(specs, proposal)
+        new_x = next(s for s in out if s.name == "StratX")
+        assert new_x.analyzers[0][1]["update_interval"] == 30
+
+    def test_unknown_strategy_raises(self):
+        proposal = MutationProposal(
+            strategy_name="Nope",
+            class_name="_DummyHeuristicA",
+            param_name="radius",
+            old_value=0.1,
+            new_value=0.2,
+            rule_kind="log_uniform_perturb",
+            rationale="t",
+        )
+        with pytest.raises(ValueError, match="not in the input spec list"):
+            apply_mutation(_make_specs(), proposal)
+
+    def test_unknown_param_raises(self):
+        proposal = MutationProposal(
+            strategy_name="StratX",
+            class_name="_DummyHeuristicA",
+            param_name="ghost",
+            old_value=0.1,
+            new_value=0.2,
+            rule_kind="log_uniform_perturb",
+            rationale="t",
+        )
+        with pytest.raises(ValueError, match="not found"):
+            apply_mutation(_make_specs(), proposal)
+
+
+# ===========================================================================
+# LoopConfig validation
+# ===========================================================================
+
+
+class TestLoopConfig:
+    def test_defaults_are_valid(self):
+        cfg = LoopConfig()
+        assert cfg.iterations == 5
+        assert cfg.guard_interval == 0  # disabled by default
+
+    def test_negative_iterations_raise(self):
+        with pytest.raises(ValueError):
+            LoopConfig(iterations=-1)
+
+    def test_unknown_mode_raises(self):
+        with pytest.raises(ValueError, match="Unknown mode"):
+            LoopConfig(mode="extreme")
+
+    def test_negative_guard_interval_raises(self):
+        with pytest.raises(ValueError, match="guard_interval"):
+            LoopConfig(guard_interval=-1)
+
+    def test_negative_guard_eps_raises(self):
+        with pytest.raises(ValueError, match="guard_eps_ladder"):
+            LoopConfig(guard_eps_ladder=-0.001)
+
+
+# ===========================================================================
+# Fake harness used to drive SelfImprover deterministically
+# ===========================================================================
+
+
+def _fake_run_record(score: float, budget: int = 100) -> RunRecord:
+    """A run that hits exactly at the eval implied by ``score``.
+
+    ``score`` is the fraction ``1 - (hit - 1)/budget`` we want, so
+    ``hit = budget * (1 - score) + 1``.  When score ≤ 0 the run "fails"
+    (no convergence).
+    """
+    if score <= 0.0:
+        return RunRecord(
+            problem_name="P",
+            problem_dim=2,
+            strategy_name="S",
+            rep=0,
+            seed=0,
+            budget=budget,
+            evaluations_used=budget,
+            best_fx=999.0,
+            f_opt=0.0,
+            func_distance=1.0,
+            tolerance=0.1,
+            success=False,
+            convergence=[],
+            heuristic_counts={},
+            duration=0.01,
+        )
+    hit = max(1, int(round(budget * (1.0 - score) + 1)))
+    from panobbgo.harness import ConvergencePoint
+
+    return RunRecord(
+        problem_name="P",
+        problem_dim=2,
+        strategy_name="S",
+        rep=0,
+        seed=0,
+        budget=budget,
+        evaluations_used=budget,
+        best_fx=0.0,
+        f_opt=0.0,
+        func_distance=0.0,
+        tolerance=0.1,
+        success=True,
+        convergence=[ConvergencePoint(eval_idx=hit, fx=0.0, func_distance=0.0)],
+        heuristic_counts={},
+        duration=0.01,
+    )
+
+
+def _fake_psr(prob: str, strat: str, scores: List[float], budget: int = 100) -> ProblemStrategyResult:
+    runs = []
+    for s in scores:
+        r = _fake_run_record(s, budget=budget)
+        r.problem_name = prob
+        r.strategy_name = strat
+        runs.append(r)
+    psr = ProblemStrategyResult(
+        problem_name=prob,
+        problem_dim=2,
+        strategy_name=strat,
+        f_opt=0.0,
+        tolerance=0.1,
+        budget=budget,
+        runs=runs,
+    )
+    psr.compute_metrics()
+    return psr
+
+
+def _fake_harness_result(
+    score: float,
+    strategy_names: Sequence[str],
+    problem_names: Sequence[str] = ("P1",),
+    n_reps: int = 5,
+) -> HarnessResult:
+    """A HarnessResult whose composite_score equals ``score``."""
+    psrs: List[ProblemStrategyResult] = []
+    for prob in problem_names:
+        for strat in strategy_names:
+            psrs.append(_fake_psr(prob, strat, [score] * n_reps))
+    composite = float(np.mean([p.score for p in psrs])) if psrs else 0.0
+    return HarnessResult(
+        config=HarnessConfig(mode="quick"),
+        timestamp="2026-01-01T00:00:00+00:00",
+        total_runs=sum(len(p.runs) for p in psrs),
+        total_duration=0.0,
+        problem_strategy_results=psrs,
+        composite_score=composite,
+    )
+
+
+@dataclass
+class _FakeHarness:
+    """Stand-in for :class:`BenchmarkHarness` in :class:`SelfImprover` tests.
+
+    The factory pattern in :class:`SelfImprover` lets us swap this in via
+    ``_harness_factory``.  Each call to ``run`` returns a deterministic
+    score chosen by ``score_fn(config) -> float`` so we can test the
+    accept/reject and guard paths precisely.
+    """
+
+    config: HarnessConfig
+    score_fn: Callable[[HarnessConfig], float] = field(default=lambda c: 0.5)
+    strategy_names: List[str] = field(default_factory=lambda: ["S"])
+    call_log: List[Dict[str, Any]] = field(default_factory=list)
+
+    def run(self, verbose: bool = False) -> HarnessResult:
+        score = float(self.score_fn(self.config))
+        self.call_log.append(
+            {
+                "score": score,
+                "randomize_iteration": self.config.randomize_iteration,
+                "n_strategies": (
+                    len(self.config.strategies_override) if self.config.strategies_override is not None else 0
+                ),
+            }
+        )
+        return _fake_harness_result(score, self.strategy_names)
+
+    def get_strategies(self) -> List[StrategySpec]:
+        # Returned only when the loop has no explicit seed_strategies.
+        return _make_specs()
+
+
+def _make_factory(
+    score_fn: Callable[[HarnessConfig], float],
+    call_log: Optional[List[Dict[str, Any]]] = None,
+) -> Callable[[HarnessConfig], _FakeHarness]:
+    log = call_log if call_log is not None else []
+    strat_names = [s.name for s in _make_specs()]
+
+    def factory(config: HarnessConfig) -> _FakeHarness:
+        return _FakeHarness(
+            config=config,
+            score_fn=score_fn,
+            strategy_names=strat_names,
+            call_log=log,
+        )
+
+    return factory
+
+
+# ===========================================================================
+# SelfImprover end-to-end with fake harness
+# ===========================================================================
+
+
+class TestSelfImproverBasic:
+    def test_runs_zero_iterations(self, tmp_path):
+        cfg = LoopConfig(
+            iterations=0,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+        )
+        si = SelfImprover(cfg, seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.5)
+        records = si.run()
+        assert records == []
+
+    def test_skip_records_when_no_applicable_mutations(self, tmp_path):
+        # Catalog with a rule that targets a class no spec has.
+        catalog = MutationCatalog(
+            [
+                MutationRule(
+                    strategy_pattern="",
+                    class_name="DoesNotExist",
+                    param_name="x",
+                    kind="float_uniform",
+                    bounds=(0.0, 1.0),
+                ),
+            ]
+        )
+        cfg = LoopConfig(
+            iterations=2,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+        )
+        si = SelfImprover(cfg, catalog=catalog, seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.5)
+        records = si.run()
+        assert len(records) == 2
+        assert all(r.proposal is None for r in records)
+        assert all(r.reason_skipped is not None for r in records)
+
+    def test_accept_strong_improvement(self, tmp_path):
+        # Catalog that always proposes a perturbation on radius.
+        catalog = MutationCatalog(
+            [
+                MutationRule(
+                    strategy_pattern="",
+                    class_name="_DummyHeuristicA",
+                    param_name="radius",
+                    kind="log_uniform_perturb",
+                    bounds=(0.005, 0.5),
+                ),
+            ]
+        )
+        # Score depends on call order: baseline call (0.3), candidate (0.7),
+        # then alternating.  Each iteration runs baseline then candidate.
+        counter = {"n": 0}
+
+        def score_fn(config: HarnessConfig) -> float:
+            n = counter["n"]
+            counter["n"] += 1
+            return 0.3 if n % 2 == 0 else 0.7
+
+        cfg = LoopConfig(
+            iterations=2,
+            n_boot=200,
+            eps_accept=0.005,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+        )
+        si = SelfImprover(cfg, catalog=catalog, seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(score_fn)
+        records = si.run()
+        assert len(records) == 2
+        # First iteration should accept the strong improvement.
+        assert records[0].accepted is True
+        assert records[0].delta > 0
+        assert records[0].baseline_score == pytest.approx(0.3)
+        assert records[0].candidate_score == pytest.approx(0.7)
+
+    def test_reject_when_score_unchanged(self, tmp_path):
+        catalog = MutationCatalog(
+            [
+                MutationRule(
+                    strategy_pattern="",
+                    class_name="_DummyHeuristicA",
+                    param_name="radius",
+                    kind="log_uniform_perturb",
+                    bounds=(0.005, 0.5),
+                ),
+            ]
+        )
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=100,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+        )
+        si = SelfImprover(cfg, catalog=catalog, seed_strategies=_make_specs())
+        # Both baseline and candidate score identically.
+        si._harness_factory = _make_factory(lambda c: 0.5)
+        records = si.run()
+        assert len(records) == 1
+        assert records[0].accepted is False
+
+    def test_stop_sentinel_halts_loop(self, tmp_path):
+        sentinel = tmp_path / "STOP"
+        sentinel.write_text("")
+        cfg = LoopConfig(
+            iterations=5,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path=str(sentinel),
+            randomize=False,
+        )
+        si = SelfImprover(cfg, seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.5)
+        records = si.run()
+        assert records == []
+
+
+# ===========================================================================
+# Anti-cherry-pick guard
+# ===========================================================================
+
+
+class TestAntiCherryPickGuard:
+    def _accept_catalog(self) -> MutationCatalog:
+        return MutationCatalog(
+            [
+                MutationRule(
+                    strategy_pattern="",
+                    class_name="_DummyHeuristicA",
+                    param_name="radius",
+                    kind="log_uniform_perturb",
+                    bounds=(0.005, 0.5),
+                ),
+            ]
+        )
+
+    def test_disabled_by_default(self, tmp_path):
+        """guard_interval=0 must produce no guard records."""
+        cfg = LoopConfig(
+            iterations=2,
+            n_boot=100,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+            guard_interval=0,
+        )
+        si = SelfImprover(cfg, catalog=self._accept_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.4)
+        iter_records, guard_records = si.run_with_guard_records()
+        assert len(iter_records) == 2
+        assert guard_records == []
+
+    def test_fires_at_correct_cadence(self, tmp_path):
+        """guard_interval=2 fires after iter 1 and iter 3 of 4 iterations."""
+        cfg = LoopConfig(
+            iterations=4,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+            guard_interval=2,
+        )
+        si = SelfImprover(cfg, catalog=self._accept_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.4)
+        _, guard_records = si.run_with_guard_records()
+        assert [g.iteration for g in guard_records] == [1, 3]
+
+    def test_no_rollback_when_within_tolerance(self, tmp_path):
+        """Guard re-measure within eps_ladder must not pop the ladder."""
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=100,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+            guard_interval=1,
+            guard_eps_ladder=0.1,
+        )
+        si = SelfImprover(cfg, catalog=self._accept_catalog(), seed_strategies=_make_specs())
+        # Constant score 0.5 — no drift between any measurements.
+        si._harness_factory = _make_factory(lambda c: 0.5)
+        _, guard_records = si.run_with_guard_records()
+        assert len(guard_records) == 1
+        assert guard_records[0].rolled_back is False
+        assert guard_records[0].pops == 0
+
+    def test_rollback_when_drift_exceeds_eps(self, tmp_path):
+        """When the guard re-measure drops below eps_ladder, the ladder rolls back."""
+        # Each call: baseline=0.3, candidate=0.8 — so iter 0 will accept
+        # decisively (Δ ≈ +0.5).  Then the guard re-measures the top of the
+        # ladder at iter_id = 1_000_000; we make that one return 0.1.
+        # Any other call (regular iteration) keeps the alternating pattern.
+        counter = {"n": 0}
+
+        def score_fn(config: HarnessConfig) -> float:
+            iter_id = config.randomize_iteration
+            if iter_id >= 1_000_000:
+                # Guard re-measure on the fresh seed — collapse.
+                return 0.1
+            n = counter["n"]
+            counter["n"] += 1
+            return 0.3 if n % 2 == 0 else 0.8
+
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=100,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+            guard_interval=1,
+            guard_eps_ladder=0.05,
+            guard_iteration_offset=1_000_000,
+        )
+        si = SelfImprover(cfg, catalog=self._accept_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(score_fn)
+        iter_records, guard_records = si.run_with_guard_records()
+        # Iteration accepted (mutated >> baseline on regular seed).
+        assert iter_records[0].accepted is True
+        # Guard rolled back — re-measure on the fresh seed showed collapse.
+        assert len(guard_records) == 1
+        assert guard_records[0].rolled_back is True
+        # Drift target was iter 0 (the just-accepted entry).
+        assert guard_records[0].pre_guard_top_iteration == 0
+        # We pop back to the seed (-1) because the ladder only has one
+        # accepted entry above the seed.
+        assert guard_records[0].rolled_back_to_iteration == -1
+        assert guard_records[0].pops == 1
+
+    def test_guard_uses_offset_iteration_id(self, tmp_path):
+        """The guard must measure at ``iter + guard_iteration_offset``."""
+        call_log: List[Dict[str, Any]] = []
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+            guard_interval=1,
+            guard_iteration_offset=42_424,
+        )
+        si = SelfImprover(cfg, catalog=self._accept_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.5, call_log=call_log)
+        si.run()
+        # Last call (the guard) should be at the offset iteration id.
+        assert call_log[-1]["randomize_iteration"] == 42_424
+
+    def test_guard_does_not_pop_seed(self, tmp_path):
+        """Even if every entry drifts, the guard never pops below the seed."""
+
+        # All measurements just return 0.0 so every entry "drifts" — but the
+        # ladder only ever has the seed (no accept), so nothing should be
+        # popped.
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+            guard_interval=1,
+        )
+        catalog = MutationCatalog(
+            [
+                MutationRule(
+                    strategy_pattern="",
+                    class_name="DoesNotExist",
+                    param_name="foo",
+                    kind="float_uniform",
+                    bounds=(0.0, 1.0),
+                ),
+            ]
+        )
+        si = SelfImprover(cfg, catalog=catalog, seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.0)
+        _, guard_records = si.run_with_guard_records()
+        # Skip-only iteration; guard still runs but ladder has one entry.
+        assert len(guard_records) == 1
+        # No accepted entries → ladder is just the seed → no pops possible.
+        assert guard_records[0].pops == 0
+
+
+# ===========================================================================
+# Ledger writing & loading
+# ===========================================================================
+
+
+class TestLedger:
+    def test_writes_iteration_and_guard_records(self, tmp_path):
+        cfg = LoopConfig(
+            iterations=2,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+            guard_interval=1,
+        )
+        si = SelfImprover(
+            cfg,
+            catalog=MutationCatalog(
+                [
+                    MutationRule(
+                        strategy_pattern="",
+                        class_name="_DummyHeuristicA",
+                        param_name="radius",
+                        kind="log_uniform_perturb",
+                        bounds=(0.005, 0.5),
+                    ),
+                ]
+            ),
+            seed_strategies=_make_specs(),
+        )
+        si._harness_factory = _make_factory(lambda c: 0.5)
+        si.run()
+
+        records = load_ledger(cfg.ledger_path)
+        # 2 iterations + 2 guard records.
+        assert len(records) == 4
+        types = [r.get("record_type") for r in records]
+        # Pattern: iter, guard, iter, guard.
+        assert types == ["iteration", "guard", "iteration", "guard"]
+
+    def test_load_ledger_missing_file_returns_empty(self, tmp_path):
+        out = load_ledger(str(tmp_path / "does-not-exist.jsonl"))
+        assert out == []
+
+    def test_iteration_record_to_dict_round_trip(self):
+        rec = LoopIterationRecord(
+            iteration=3,
+            timestamp="2026-01-01T00:00:00+00:00",
+            duration_seconds=1.0,
+            proposal={"strategy_name": "S", "class_name": "C", "param_name": "p"},
+            accepted=True,
+            baseline_score=0.4,
+            candidate_score=0.6,
+            delta=0.2,
+            ci_low=0.05,
+            ci_high=0.35,
+            worst_pair_regression=-0.01,
+            worst_pair=("P", "S"),
+            reasons=["ok"],
+            base_seed=42,
+            randomize_iteration=3,
+            mode="quick",
+        )
+        d = rec.to_dict()
+        assert d["record_type"] == "iteration"
+        assert d["iteration"] == 3
+        assert d["worst_pair"] == ["P", "S"]
+        # JSON-serialisable end-to-end.
+        assert json.loads(json.dumps(d))
+
+    def test_guard_record_to_dict_round_trip(self):
+        rec = LoopGuardRecord(
+            iteration=4,
+            timestamp="2026-01-01T00:00:00+00:00",
+            duration_seconds=0.5,
+            guard_score=0.45,
+            pre_guard_top_score=0.55,
+            pre_guard_top_iteration=2,
+            rolled_back=True,
+            rolled_back_to_iteration=1,
+            pops=1,
+            ladder_size_before=3,
+            ladder_size_after=2,
+            guard_iteration_id=1_000_004,
+            reasons=["drift"],
+        )
+        d = rec.to_dict()
+        assert d["record_type"] == "guard"
+        assert d["pops"] == 1
+        # JSON-serialisable end-to-end.
+        assert json.loads(json.dumps(d))
+
+
+# ===========================================================================
+# LadderEntry sanity
+# ===========================================================================
+
+
+class TestLadderEntry:
+    def test_construct(self):
+        e = LadderEntry(iteration=-1, specs=_make_specs(), last_validated_score=float("nan"))
+        assert e.iteration == -1
+        assert np.isnan(e.last_validated_score)
+        assert e.proposal is None


### PR DESCRIPTION
## Summary

Closes the **anti-cherry-pick guard** gap from `planning/SELF_IMPROVEMENT_LOOP.md` §6.3 and fills the test gap left by the Phase 5 MVP loop driver.

Without the guard, an unattended self-improvement run can drift: a sequence of "lucky" instance draws inflates per-iteration `after` scores enough to clear the bootstrap CI even when the underlying mutation does not generalise. The guard mitigates this by **periodically re-measuring the top of the accepted ladder on a fresh randomized seed** and rolling the ladder back when the composite has dropped below tolerance. This is what makes the loop trustworthy enough to run unattended.

This is the single highest-priority improvement on the path to a self-improving panobbgo: it directly addresses §2 ("what's missing for a true self-improvement loop"), §6.3 ("anti-cherry-pick guard"), and §11 ("no regression worse than −0.02 on any individual pair").

## What changed

**`panobbgo/self_improve.py`**
- New `LoopConfig.guard_interval` / `guard_eps_ladder` / `guard_iteration_offset` (disabled by default → backward compatible).
- New `LadderEntry` (snapshot of an accepted spec list with its `last_validated_score`) and `LoopGuardRecord` (one ledger line per guard check).
- `LoopIterationRecord` gains `record_type = "iteration"` so consumers can tell iteration and guard records apart.
- `SelfImprover.run_with_guard_records()` returns iteration and guard records separately; `run()` keeps its existing return contract.
- Guard re-measures the top entry on `randomize_iteration = iteration + guard_iteration_offset` and walks down on drift; the seed entry is the trusted fallback and is never popped.

**`scripts/self_improve.py`**
- New CLI flags: `--guard-interval`, `--guard-eps-ladder`, `--guard-iteration-offset`.
- `summary` distinguishes iteration / guard records and reports rollbacks.

**`tests/test_self_improve.py`** (new, 40 tests)
- `MutationRule` validation, `MutationCatalog` sampling (all three kinds), `apply_mutation` immutability, `LoopConfig` validation.
- End-to-end `SelfImprover` with a faked harness: zero iterations, skip, accept, reject, STOP sentinel.
- Anti-cherry-pick guard: cadence, no-rollback when stable, rollback on drift, offset iteration id usage, seed not popped.
- Ledger round-trip with mixed iteration / guard records.

**Documentation**
- `planning/SELF_IMPROVEMENT_LOOP.md`: §6.3 marked shipped, §2 list refreshed, Phase 5 / Phase 6 checklists updated, new §12 "Next iteration ideas" listing adaptive mutation sampler, stratified dimension sampling, strategy portfolio composition, and hold-out validation set as carry-over tickets.
- `doc/source/guide_benchmarking.rst`: new "Anti-cherry-pick guard (§6.3)" subsection with algorithm, programmatic example, defaults rationale.
- `doc/source/guide.rst`: quick-nav entry mentions loop driver and guard.
- `AGENTS.md`: self-improvement loop subsection updated with shipped status and `scripts/self_improve.py` examples.
- `TODO.md`: full entry.

## Algorithm

```
every guard_interval iterations (after a regular accept/reject):
    re-measure ladder.top on randomize_iteration = iter + guard_iteration_offset
    if score >= top.last_validated_score - guard_eps_ladder:
        refresh top.last_validated_score and continue
    else:
        pop top; re-measure new top; repeat
        until a stable entry is found or the seed is reached
```

The offset (default `1_000_000`) keeps the guard's instance stream independent from the regular iteration stream, so a mutation cannot accidentally tune itself to seeds the guard would reuse.

## Test plan

- [x] `uv run pytest tests/test_self_improve.py` — 40 passed.
- [x] `uv run pytest tests/ -x` (full suite) — 758 passed, 1 skipped (Dask), 0 failures.
- [x] `uv run pyright panobbgo` — 0 errors, 0 warnings.
- [x] `uv run ruff format --check .` — clean.
- [x] `uv run flake8 panobbgo --select=E9,F63,F7,F82` — clean.
- [x] `uv run sphinx-build -b doctest doc/source doc/build/doctest` — 96 doctests pass.
- [x] `uv run python scripts/self_improve.py run --help` — new flags exposed.

## Backward compatibility

`guard_interval` defaults to `0` (disabled). Existing ledgers, tests, and CLI invocations behave identically. New `record_type` field is additive: old ledger consumers that don't read it still work.

https://claude.ai/code/session_01B8uhbhRGiNrxnUogjtqsFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8uhbhRGiNrxnUogjtqsFY)_