### PR TITLE
feat(self_improve): Thompson-sampling adaptive mutation sampler (§10)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,15 @@ The harness is the measurement substrate for an autonomous
     guard periodically re-measures the top of the accepted ladder on
     a fresh randomized seed and rolls back if the composite drifts
     below tolerance, catching instance cherry-picking.
+*   Adaptive mutation sampler (Thompson sampling) — **shipped** (§10),
+    see `panobbgo.self_improve.AdaptiveMutationSampler` and the
+    `--adaptive`, `--adaptive-prior-alpha`, `--adaptive-prior-beta`,
+    `--adaptive-prime-from-ledger` CLI flags.  The sampler treats each
+    mutation rule as a Bernoulli arm with reward = "iteration was
+    accepted" and biases future samples toward rules with positive
+    accept history while still exploring under-tried rules.
+    Cold-start (Beta(1, 1) prior) is statistically identical to uniform
+    sampling.
 
 Run the loop:
 
@@ -221,6 +230,10 @@ uv run python scripts/self_improve.py run --iterations 5
 # Long run with the anti-cherry-pick guard every 10 iterations
 uv run python scripts/self_improve.py run --iterations 100 \
     --mode standard --guard-interval 10 --guard-eps-ladder 0.02
+
+# Adaptive (Thompson-sampling) mutation sampler primed from a prior ledger
+uv run python scripts/self_improve.py run --iterations 100 \
+    --adaptive --adaptive-prime-from-ledger
 
 # Inspect the ledger
 uv run python scripts/self_improve.py summary

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,66 @@
 
 ## Recent Improvements (continued)
 
+### Adaptive Mutation Sampler (Thompson Sampling) for Self-Improvement Loop (2026-05-01)
+- [x] **New `panobbgo.self_improve.AdaptiveMutationSampler`** — Thompson-
+      sampling bandit over per-rule Beta posteriors; closes the §10
+      "Adaptive mutation sampler" item in
+      `planning/SELF_IMPROVEMENT_LOOP.md`.  Each
+      :class:`MutationRule` becomes one arm whose reward is "iteration was
+      accepted"; on `sample()` the sampler draws one variate from
+      ``Beta(prior_alpha + n_accepts, prior_beta + n_attempts -
+      n_accepts)`` per applicable rule and picks the arg-max.  Inside the
+      chosen rule, hits are still selected uniformly (which spec / which
+      slot), exactly like the catalog's uniform sampler.
+  - **Why it matters.** The uniform catalog sampler shipped in Phase 5
+    wastes iterations on rules that never produce accepts.  Thompson
+    sampling concentrates probability on empirically winning rules
+    while still exploring under-tried rules — the standard fix for the
+    productivity gap of multi-armed bandit problems.  Cold-start
+    equivalence to uniform (Beta(1, 1) ≡ U(0, 1), arg-max of i.i.d.
+    uniforms is uniform) makes the upgrade strictly safe.
+  - **History persistence.** `prime_from_ledger(path)` replays
+    iteration records from a prior JSONL ledger so the bandit resumes
+    with all the meta-knowledge of which rules have worked so far —
+    directly supports unattended multi-hour loops.
+- [x] **`MutationRuleStats` dataclass + public `RuleKey` alias** —
+      JSON-serialisable per-rule accept/attempt history bucketed by
+      ``(class_name, param_name, rule_kind)``.
+- [x] **`LoopConfig` knobs** — `adaptive_sampling`,
+      `adaptive_prior_alpha`, `adaptive_prior_beta`,
+      `adaptive_prime_from_ledger`; all default to off / symmetric prior
+      so existing CLI invocations behave identically.  Negative or zero
+      priors raise at validation time.
+- [x] **`SelfImprover` integration** — accepts an explicit `sampler=`
+      keyword for tests; otherwise constructs the sampler from
+      `LoopConfig` when `adaptive_sampling=True`.  After each iteration's
+      accept/reject decision, the driver calls
+      ``sampler.record_outcome()`` so future samples are biased toward
+      winning rules.
+- [x] **CLI flags** `--adaptive`, `--adaptive-prior-alpha`,
+      `--adaptive-prior-beta`, `--adaptive-prime-from-ledger` on
+      `scripts/self_improve.py run`; the run summary prints per-rule
+      accept rates when the sampler is enabled.
+- [x] **23 new tests in `tests/test_self_improve.py`** (total 63):
+      invalid priors, cold-start uniform behaviour, arg-max bias toward
+      winning rules after biased training, record-outcome correctness
+      including no-op after `None` sample / skip iterations, ledger
+      priming (with guards / skips correctly ignored), `MutationRuleStats`
+      round-trip, `SelfImprover` integration with the `sampler=`
+      override, the `adaptive_prime_from_ledger` flag, and
+      `LoopConfig` validation.
+- [x] **Documentation updated**
+  - `planning/SELF_IMPROVEMENT_LOOP.md`: §6 Phase-6 checklist marked
+    shipped; new §12 dated entry under iteration log;
+    "Next iteration ideas" reduced and gains a hierarchical-bandit
+    follow-up ticket.
+  - `doc/source/guide_benchmarking.rst`: new "Adaptive mutation sampler
+    (§10)" subsection with algorithm, CLI examples, programmatic
+    example, cold-start equivalence proof sketch.
+  - `AGENTS.md`: self-improvement loop subsection lists the adaptive
+    sampler with run-the-loop bash example.
+  - This TODO entry.
+
 ### Sobol' Quasi-Random Initial Design Heuristic (2026-04-27)
 - [x] **New `panobbgo/heuristics/sobol.py`** — `Sobol` heuristic, a one-shot
       low-discrepancy quasi-random sampler that produces space-filling initial

--- a/doc/source/guide_benchmarking.rst
+++ b/doc/source/guide_benchmarking.rst
@@ -527,6 +527,82 @@ Programmatic use:
    )
    iter_records, guard_records = SelfImprover(cfg).run_with_guard_records()
 
+Adaptive mutation sampler (§10)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default the loop draws mutation rules uniformly at random from the
+applicable ones in :func:`~panobbgo.self_improve.default_catalog`.  In
+practice some rules (e.g. ``Nearby.radius``, ``CMAES.sigma0``) tend to
+produce accepts much more often than others, and uniform sampling
+wastes iterations on rules that never help.
+
+When ``LoopConfig.adaptive_sampling`` is enabled, the loop substitutes
+:class:`~panobbgo.self_improve.AdaptiveMutationSampler` — a
+**Thompson-sampling bandit** over per-rule Beta posteriors:
+
+1. For each mutation rule we maintain an accept/attempt counter
+   ``(n_accepts, n_attempts)``.  Skip iterations don't count.
+2. On every ``sample()`` call the sampler draws one variate from
+   ``Beta(prior_alpha + n_accepts, prior_beta + n_attempts -
+   n_accepts)`` per *applicable* rule.
+3. The arg-max of those variates wins — Thompson's
+   exploration/exploitation rule.
+4. After the iteration, the loop calls ``record_outcome(accepted)``
+   which updates the chosen rule's counters.
+
+Cold-start equivalence to uniform.  With the default symmetric prior
+:math:`\\mathrm{Beta}(1, 1)`, every posterior is :math:`\\mathrm{U}(0,
+1)` and the arg-max of i.i.d. uniforms is itself uniform — so the very
+first sample is statistically indistinguishable from
+:meth:`~panobbgo.self_improve.MutationCatalog.sample`.  Flipping the
+flag on a fresh ledger is therefore safe; behaviour diverges from
+uniform only as evidence accumulates.
+
+Resuming a long run.  Setting
+``LoopConfig.adaptive_prime_from_ledger = True`` replays accept
+history from any existing JSONL ledger before the first iteration.
+Useful when restarting a multi-hour loop after a crash or a manual
+stop — the bandit resumes with all the meta-knowledge of which rules
+have worked so far.
+
+CLI:
+
+.. code-block:: bash
+
+   # Adaptive sampler with the default symmetric prior, primed from any
+   # ledger sitting at the default path
+   uv run python scripts/self_improve.py run --iterations 50 \
+       --adaptive --adaptive-prime-from-ledger
+
+   # Greedier prior for shorter exploratory loops
+   uv run python scripts/self_improve.py run --iterations 20 \
+       --adaptive --adaptive-prior-alpha 0.5 --adaptive-prior-beta 0.5
+
+Programmatic use:
+
+.. code-block:: python
+
+   from panobbgo.self_improve import LoopConfig, SelfImprover
+
+   cfg = LoopConfig(
+       iterations=100,
+       mode="standard",
+       adaptive_sampling=True,
+       adaptive_prior_alpha=1.0,
+       adaptive_prior_beta=1.0,
+       adaptive_prime_from_ledger=True,  # learn from prior runs
+       guard_interval=10,
+   )
+   improver = SelfImprover(cfg)
+   improver.run()
+
+   # Inspect the bandit afterwards.
+   for stats in improver.sampler.stats_snapshot():
+       print(stats.rule_key, stats.n_accepts, "/", stats.n_attempts)
+
+The sampler is **off by default** (``adaptive_sampling = False``) for
+backward compatibility.
+
 
 Extending the harness
 ---------------------

--- a/panobbgo/self_improve.py
+++ b/panobbgo/self_improve.py
@@ -58,6 +58,20 @@ The mutation sampler uses its own seeded RNG
 A loop of ``N`` iterations is fully replayable from
 ``(base_seed, mutation_seed, stat_seed)``.
 
+Adaptive mutation sampler (§10)
+-------------------------------
+
+By default the loop draws mutations uniformly from the applicable rules
+of the catalog.  When ``LoopConfig.adaptive_sampling = True``, the loop
+substitutes :class:`AdaptiveMutationSampler` — a Thompson-sampling
+bandit over per-rule Beta posteriors that biases future iterations
+toward rules with positive accept history while still exploring
+under-tried rules.  Cold-start (no history, default symmetric prior) is
+statistically identical to uniform sampling, so flipping the flag is
+safe on a fresh ledger.  Set
+``LoopConfig.adaptive_prime_from_ledger = True`` to seed the bandit's
+history from a prior JSONL ledger when resuming a long run.
+
 Anti-cherry-pick guard (§6.3)
 -----------------------------
 
@@ -328,6 +342,242 @@ class MutationCatalog:
         raise ValueError(f"Unknown mutation kind: {rule.kind!r}")
 
 
+# ---------------------------------------------------------------------------
+# Adaptive (Thompson-sampling) mutation sampler
+# ---------------------------------------------------------------------------
+
+
+# Identifier used to bucket accept/attempt history.  Keeping it a small tuple
+# of native strings keeps stats reproducible across processes and trivially
+# JSON-serialisable.  ``(class_name, param_name, rule_kind)`` is what every
+# ledger record exposes via ``MutationProposal.to_dict()``, so the sampler's
+# history can be replayed from a prior run without ambiguity.
+RuleKey = Tuple[str, str, str]
+
+
+@dataclass
+class MutationRuleStats:
+    """Per-rule accept/attempt history maintained by :class:`AdaptiveMutationSampler`.
+
+    Attributes:
+        rule_key: ``(class_name, param_name, rule_kind)`` identifying the
+            mutation type.  Two :class:`MutationRule` instances that
+            differ only in ``strategy_pattern`` *share* one stats bucket
+            — they are conceptually the same dial and the bandit treats
+            them as one arm.
+        n_attempts: Number of times :meth:`AdaptiveMutationSampler.sample`
+            picked a rule with this key *and* the iteration produced a
+            decision (accept or reject).  Skip records do not count.
+        n_accepts: Number of those attempts that the loop accepted.
+    """
+
+    rule_key: RuleKey
+    n_attempts: int = 0
+    n_accepts: int = 0
+
+    @property
+    def accept_rate(self) -> float:
+        """Empirical accept rate, or 0.0 with no attempts."""
+        if self.n_attempts == 0:
+            return 0.0
+        return self.n_accepts / self.n_attempts
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "class_name": self.rule_key[0],
+            "param_name": self.rule_key[1],
+            "rule_kind": self.rule_key[2],
+            "n_attempts": int(self.n_attempts),
+            "n_accepts": int(self.n_accepts),
+            "accept_rate": float(self.accept_rate),
+        }
+
+
+def _proposal_rule_key(class_name: str, param_name: str, rule_kind: str) -> RuleKey:
+    return (str(class_name), str(param_name), str(rule_kind))
+
+
+class AdaptiveMutationSampler:
+    """Thompson-sampling wrapper over :class:`MutationCatalog`.
+
+    Closes the *Adaptive mutation sampler* item from §10 of
+    ``planning/SELF_IMPROVEMENT_LOOP.md``.  Each mutation rule is treated as
+    one arm of a Bernoulli bandit whose reward is "this iteration was
+    accepted".  Per-rule history is summarised by a Beta posterior::
+
+        Beta(prior_alpha + n_accepts, prior_beta + n_attempts - n_accepts)
+
+    On every :meth:`sample` call the sampler draws one variate from each
+    applicable rule's posterior and picks the arg-max — the canonical
+    Thompson-sampling rule.  Within the chosen rule, the concrete hit
+    (which strategy spec / which slot) is selected uniformly, exactly as
+    :meth:`MutationCatalog.sample` does today.
+
+    The accept history is updated by :meth:`record_outcome`, which the
+    :class:`SelfImprover` invokes after every iteration's
+    statistical-acceptance decision (skip iterations are no-ops).  The
+    sampler can also be primed from a prior JSONL ledger via
+    :meth:`prime_from_ledger`, so the loop carries learning across
+    restarts of the driver.
+
+    Cold-start equivalence to uniform sampling.  With the defaults
+    ``prior_alpha = prior_beta = 1`` and zero history, every Beta
+    posterior is :math:`\\mathrm{U}(0, 1)`.  The arg-max of i.i.d.
+    uniforms is itself uniform — so the very first sample is statistically
+    indistinguishable from :meth:`MutationCatalog.sample`.
+
+    Args:
+        catalog: The underlying :class:`MutationCatalog`.  The adaptive
+            sampler does not modify it; it only re-weights how rules are
+            selected.
+        prior_alpha: Pseudo-count of "successes" in the Beta prior.  Larger
+            values flatten the posterior and slow learning; smaller values
+            (e.g. ``0.5``) make the sampler greedier earlier.  Must be > 0.
+        prior_beta: Pseudo-count of "failures" in the Beta prior.  Same
+            shape as ``prior_alpha``; defaults to a symmetric ``Beta(1, 1)``.
+            Must be > 0.
+
+    Raises:
+        ValueError: If either prior is non-positive.
+    """
+
+    def __init__(
+        self,
+        catalog: MutationCatalog,
+        prior_alpha: float = 1.0,
+        prior_beta: float = 1.0,
+    ) -> None:
+        if prior_alpha <= 0 or prior_beta <= 0:
+            raise ValueError(f"prior_alpha and prior_beta must be > 0, got {prior_alpha!r}, {prior_beta!r}")
+        self.catalog = catalog
+        self.prior_alpha = float(prior_alpha)
+        self.prior_beta = float(prior_beta)
+        self._stats: Dict[RuleKey, MutationRuleStats] = {}
+        self._last_rule_key: Optional[RuleKey] = None
+
+    @staticmethod
+    def _rule_key(rule: MutationRule) -> RuleKey:
+        return _proposal_rule_key(rule.class_name, rule.param_name, rule.kind)
+
+    def get_stats(self, rule: MutationRule) -> MutationRuleStats:
+        """Return (creating if needed) the stats bucket for ``rule``."""
+        key = self._rule_key(rule)
+        if key not in self._stats:
+            self._stats[key] = MutationRuleStats(rule_key=key)
+        return self._stats[key]
+
+    def stats_snapshot(self) -> List[MutationRuleStats]:
+        """Return all rule stats sorted by key (stable across calls)."""
+        return [self._stats[k] for k in sorted(self._stats.keys())]
+
+    @property
+    def last_rule_key(self) -> Optional[RuleKey]:
+        """Rule key of the most recent :meth:`sample` call, or ``None``."""
+        return self._last_rule_key
+
+    def sample(
+        self,
+        rng: np.random.Generator,
+        specs: Sequence[StrategySpec],
+    ) -> Optional[MutationProposal]:
+        """Draw one applicable mutation, biased by Beta posteriors.
+
+        Returns ``None`` iff no rule matches ``specs`` — same contract as
+        :meth:`MutationCatalog.sample`.  When that happens,
+        :attr:`last_rule_key` is reset to ``None`` so a subsequent
+        :meth:`record_outcome` is a safe no-op.
+        """
+        applicable = self.catalog.applicable_rules(specs)
+        if not applicable:
+            self._last_rule_key = None
+            return None
+
+        # Thompson: one Beta draw per applicable rule, pick the arg-max.
+        n = len(applicable)
+        sampled = np.empty(n, dtype=np.float64)
+        for i, (rule, _) in enumerate(applicable):
+            stats = self.get_stats(rule)
+            alpha = self.prior_alpha + stats.n_accepts
+            beta_param = self.prior_beta + (stats.n_attempts - stats.n_accepts)
+            sampled[i] = float(rng.beta(alpha, beta_param))
+        chosen_idx = int(np.argmax(sampled))
+        rule, hits = applicable[chosen_idx]
+
+        hit_idx = int(rng.integers(0, len(hits)))
+        si, _, _, old_value = hits[hit_idx]
+        strategy_name = specs[si].name
+        new_value = MutationCatalog._mutate_value(rule, old_value, rng)
+
+        chosen_stats = self.get_stats(rule)
+        alpha_eff = self.prior_alpha + chosen_stats.n_accepts
+        beta_eff = self.prior_beta + (chosen_stats.n_attempts - chosen_stats.n_accepts)
+        rationale = (
+            f"{rule.kind} on {rule.class_name}.{rule.param_name} in {strategy_name}: "
+            f"{old_value!r} -> {new_value!r} "
+            f"[Thompson Beta({alpha_eff:.1f}, {beta_eff:.1f}); draw={sampled[chosen_idx]:.3f}; "
+            f"history {chosen_stats.n_accepts}/{chosen_stats.n_attempts}]"
+        )
+        self._last_rule_key = self._rule_key(rule)
+        return MutationProposal(
+            strategy_name=strategy_name,
+            class_name=rule.class_name,
+            param_name=rule.param_name,
+            old_value=_to_plain(old_value),
+            new_value=_to_plain(new_value),
+            rule_kind=rule.kind,
+            rationale=rationale,
+        )
+
+    def record_outcome(self, accepted: bool) -> None:
+        """Update the bandit with the most recent iteration's verdict.
+
+        No-op when :attr:`last_rule_key` is ``None`` — i.e. when the
+        previous iteration was a skip or :meth:`sample` was never called
+        — so the driver can call this unconditionally on every
+        iteration.
+        """
+        if self._last_rule_key is None:
+            return
+        stats = self._stats.setdefault(
+            self._last_rule_key,
+            MutationRuleStats(rule_key=self._last_rule_key),
+        )
+        stats.n_attempts += 1
+        if accepted:
+            stats.n_accepts += 1
+        self._last_rule_key = None
+
+    def prime_from_ledger(self, ledger_path: str) -> int:
+        """Seed the bandit's history from a prior JSONL ledger.
+
+        Replays every iteration record with a non-null proposal: each
+        contributes ``n_attempts += 1`` and, if accepted, also ``n_accepts
+        += 1``.  Skip records and guard records are ignored.  Returns the
+        number of records consumed.
+
+        Useful for resuming a long unattended loop run without losing
+        the meta-knowledge of which mutation rules tend to succeed.
+        """
+        consumed = 0
+        for rec in load_ledger(ledger_path):
+            if rec.get("record_type", "iteration") != "iteration":
+                continue
+            proposal = rec.get("proposal")
+            if proposal is None:
+                continue
+            key = _proposal_rule_key(
+                proposal.get("class_name", ""),
+                proposal.get("param_name", ""),
+                proposal.get("rule_kind", ""),
+            )
+            stats = self._stats.setdefault(key, MutationRuleStats(rule_key=key))
+            stats.n_attempts += 1
+            if rec.get("accepted"):
+                stats.n_accepts += 1
+            consumed += 1
+        return consumed
+
+
 def default_catalog() -> MutationCatalog:
     """Return the built-in hyperparameter mutation catalog.
 
@@ -531,6 +781,23 @@ class LoopConfig:
             stream independent from the regular iteration stream so a
             mutation cannot accidentally tune itself to the guard's
             seeds.
+        adaptive_sampling: If ``True``, the loop replaces uniform
+            mutation sampling with :class:`AdaptiveMutationSampler` —
+            Thompson sampling over a Beta posterior per rule.  Defaults
+            to ``False`` so existing CLI invocations behave identically.
+            With this flag, the loop biases future iterations toward
+            rules that have produced accepts in the past while still
+            exploring less-tried rules.
+        adaptive_prior_alpha: Pseudo-count of "successes" in the Beta
+            prior used by the adaptive sampler.  Has no effect unless
+            :attr:`adaptive_sampling` is ``True``.
+        adaptive_prior_beta: Pseudo-count of "failures" in the Beta
+            prior; symmetric default ``1.0`` ⇒ Beta(1, 1) ≡ U(0, 1) so
+            cold-start behaviour matches uniform sampling.
+        adaptive_prime_from_ledger: When ``True``, the adaptive sampler
+            seeds its bandit history from any existing
+            :attr:`ledger_path` before the first iteration.  Useful when
+            resuming a long unattended run.
     """
 
     iterations: int = 5
@@ -552,6 +819,10 @@ class LoopConfig:
     guard_interval: int = 0
     guard_eps_ladder: float = 0.02
     guard_iteration_offset: int = 1_000_000
+    adaptive_sampling: bool = False
+    adaptive_prior_alpha: float = 1.0
+    adaptive_prior_beta: float = 1.0
+    adaptive_prime_from_ledger: bool = False
 
     def __post_init__(self) -> None:
         if self.iterations < 0:
@@ -562,6 +833,10 @@ class LoopConfig:
             raise ValueError(f"guard_interval must be >= 0, got {self.guard_interval}")
         if self.guard_eps_ladder < 0:
             raise ValueError(f"guard_eps_ladder must be >= 0, got {self.guard_eps_ladder}")
+        if self.adaptive_prior_alpha <= 0:
+            raise ValueError(f"adaptive_prior_alpha must be > 0, got {self.adaptive_prior_alpha}")
+        if self.adaptive_prior_beta <= 0:
+            raise ValueError(f"adaptive_prior_beta must be > 0, got {self.adaptive_prior_beta}")
 
     def harness_config(
         self,
@@ -764,12 +1039,28 @@ class SelfImprover:
         config: Optional[LoopConfig] = None,
         catalog: Optional[MutationCatalog] = None,
         seed_strategies: Optional[Sequence[StrategySpec]] = None,
+        sampler: Optional[AdaptiveMutationSampler] = None,
     ) -> None:
         self.config = config or LoopConfig()
         self.catalog = catalog or default_catalog()
         self._seed_strategies: Optional[List[StrategySpec]] = (
             list(seed_strategies) if seed_strategies is not None else None
         )
+        # The adaptive sampler is constructed lazily when requested.  An
+        # explicit instance always wins so tests / callers can pass a
+        # pre-primed sampler.
+        if sampler is not None:
+            self.sampler: Optional[AdaptiveMutationSampler] = sampler
+        elif self.config.adaptive_sampling:
+            self.sampler = AdaptiveMutationSampler(
+                self.catalog,
+                prior_alpha=self.config.adaptive_prior_alpha,
+                prior_beta=self.config.adaptive_prior_beta,
+            )
+            if self.config.adaptive_prime_from_ledger:
+                self.sampler.prime_from_ledger(self.config.ledger_path)
+        else:
+            self.sampler = None
         # Late-bound so tests can swap a fake harness in.
         self._harness_factory = BenchmarkHarness
 
@@ -819,7 +1110,7 @@ class SelfImprover:
 
             start = time.time()
 
-            proposal = self.catalog.sample(rng, current)
+            proposal = self._sample_proposal(rng, current)
             if proposal is None:
                 rec = self._skip_record(iteration, start, "no applicable mutations for current specs")
                 records.append(rec)
@@ -886,6 +1177,12 @@ class SelfImprover:
             if np.isnan(ladder[0].last_validated_score):
                 ladder[0].last_validated_score = float(baseline_result.composite_score)
 
+            # Update the adaptive bandit *before* swapping the ladder so
+            # the rule key recorded by `_sample_proposal` still matches
+            # this iteration's outcome.  Uniform-sampler runs do nothing.
+            if self.sampler is not None:
+                self.sampler.record_outcome(bool(decision.accept))
+
             if decision.accept:
                 current = candidate
                 ladder.append(
@@ -911,6 +1208,21 @@ class SelfImprover:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _sample_proposal(
+        self,
+        rng: np.random.Generator,
+        specs: List[StrategySpec],
+    ) -> Optional[MutationProposal]:
+        """Delegate to the adaptive sampler if configured, else the catalog.
+
+        Centralising the call site lets :meth:`_run_internal` stay
+        agnostic to which sampler is in use, and ensures the bandit's
+        ``last_rule_key`` is set the same way an explicit caller would.
+        """
+        if self.sampler is not None:
+            return self.sampler.sample(rng, specs)
+        return self.catalog.sample(rng, specs)
 
     def _load_seed_strategies(self) -> List[StrategySpec]:
         if self._seed_strategies is not None:
@@ -1153,6 +1465,9 @@ __all__ = [
     "MutationRule",
     "MutationProposal",
     "MutationCatalog",
+    "MutationRuleStats",
+    "AdaptiveMutationSampler",
+    "RuleKey",
     "default_catalog",
     "apply_mutation",
     "LoopConfig",

--- a/planning/SELF_IMPROVEMENT_LOOP.md
+++ b/planning/SELF_IMPROVEMENT_LOOP.md
@@ -376,10 +376,17 @@ Each phase is independently deliverable and keeps the framework usable.
 ### Phase 6 — Production loop (ongoing)
 
 - [x] Anti-cherry-pick guard (§6.3) — shipped 2026-04-26.
+- [x] Adaptive mutation sampler (§10) — shipped 2026-05-01 as
+      :class:`panobbgo.self_improve.AdaptiveMutationSampler` plus the
+      ``LoopConfig.adaptive_sampling`` / ``adaptive_prior_alpha`` /
+      ``adaptive_prior_beta`` / ``adaptive_prime_from_ledger`` knobs and
+      the ``--adaptive`` family of CLI flags.  Thompson sampling on
+      per-rule Beta posteriors; cold-start (Beta(1,1)) is statistically
+      identical to uniform sampling, so flipping the flag is safe on a
+      fresh ledger.  History can be primed from a prior JSONL ledger
+      when resuming a long run.
 - [ ] Broaden the mutation space (strategy portfolio composition,
       analyzer add/drop — §7 items 2–3).
-- [ ] Adaptive mutation sampler (§10): bias future samples toward
-      rules with positive accept history.
 - [ ] Stratified dimension sampling (§10) for cross-iteration score
       stability.
 - [ ] Connect the loop to CI (nightly run on a dedicated runner).
@@ -394,7 +401,11 @@ Each phase is independently deliverable and keeps the framework usable.
 - **What if the accept rate is too low?** Most proposed mutations will be
   no-ops or regressions. This is normal; the loop needs patience or a
   smarter proposer (a simple Bayesian optimiser over the hyperparameter
-  space is a natural upgrade).
+  space is a natural upgrade).  A first-order improvement shipped
+  2026-05-01: :class:`AdaptiveMutationSampler` (Thompson sampling over
+  per-rule Beta posteriors), enabled by ``LoopConfig.adaptive_sampling``.
+  This biases future iterations toward rules with positive accept
+  history while still exploring under-tried rules.
 - **Composite score stability across dimension sampling.** If we sample
   `d ∈ {2, 5, 10}` we need to *stratify* (same mix of dimensions on both
   sides of the comparison) or the score will be dominated by whichever
@@ -424,6 +435,46 @@ This section records direct algorithmic improvements applied to Panobbgo
 *outside* of the autonomous loop, so the human-in-the-loop history stays
 greppable.  Each entry should reference the PR / commit that landed it,
 the rationale, and a measured-impact number when available.
+
+### 2026-05-01 — Adaptive mutation sampler (Thompson sampling)
+
+* **What** — `panobbgo/self_improve.py` gains
+  `AdaptiveMutationSampler` plus `MutationRuleStats` and the public
+  `RuleKey` alias.  Each :class:`MutationRule` becomes one arm of a
+  Bernoulli bandit whose reward is "this iteration was accepted".  On
+  every `sample()` call the sampler draws one variate per applicable
+  rule from `Beta(prior_alpha + n_accepts, prior_beta + n_attempts -
+  n_accepts)` and picks the arg-max — the canonical Thompson rule.
+  Inside the chosen rule, hits are still selected uniformly (which
+  spec / which slot), exactly as the catalog's uniform sampler does.
+  History is primed from a prior JSONL ledger via
+  `prime_from_ledger`, so the loop carries learning across restarts.
+  `LoopConfig` gains `adaptive_sampling`, `adaptive_prior_alpha`,
+  `adaptive_prior_beta`, `adaptive_prime_from_ledger`; the
+  `scripts/self_improve.py` CLI gains the `--adaptive` family of
+  flags.  After each iteration's accept/reject decision, the driver
+  calls `sampler.record_outcome()` so future samples are biased
+  toward rules with positive accept history.
+* **Why** — closes the §10 "Adaptive mutation sampler" item.  The
+  uniform catalog sampler shipped in Phase 5 wastes iterations on
+  rules that never produce accepts.  Thompson sampling concentrates
+  probability mass on empirically winning rules while still exploring
+  unfamiliar ones — the canonical fix for the *productivity* gap of
+  multi-armed bandit problems.  Cold-start equivalence to uniform
+  (Beta(1, 1) ≡ U(0, 1), and arg-max of i.i.d. uniforms is uniform)
+  makes the upgrade strictly safe: flipping the flag on a fresh
+  ledger reproduces the prior behaviour distributionally, then
+  diverges as evidence accumulates.
+* **Defaults** — `adaptive_sampling = False` keeps existing CLI
+  invocations byte-identical.  `adaptive_prior_alpha = adaptive_prior_beta
+  = 1.0` is the symmetric uninformed prior; lower priors (e.g. `0.5`)
+  make the sampler greedier earlier at the cost of more variance.
+* **Tests** — `tests/test_self_improve.py` (23 new tests, total 63):
+  invalid priors, cold-start equivalence to uniform sampling,
+  arg-max behaviour after biased training, record-outcome
+  correctness, ledger priming, integration with `SelfImprover`
+  including the `sampler=` override and the `adaptive_prime_from_ledger`
+  flag.
 
 ### 2026-04-27 — Sobol' quasi-random initial design (`Sobol` heuristic)
 
@@ -481,22 +532,17 @@ the rationale, and a measured-impact number when available.
 Lightweight "next ticket" notes for follow-up agents — graduate them to
 a dated entry above when shipped.
 
-#### Adaptive mutation sampler (§10 productivity)
+#### Contextual / hierarchical bandit over mutation rules
 
-The current `MutationCatalog` samples uniformly from the applicable
-rules.  After several iterations the loop has direct evidence about
-which rules tend to produce accepts.  A simple Beta-Bernoulli or UCB
-scheme over rules — keyed by `(class_name, param_name, rule_kind)` —
-would bias future samples toward rules with positive accept history
-while still exploring unfamiliar ones.
-
-Suggested implementation sketch:
-
-- Track `(n_attempts, n_accepts)` per rule key, persisted across loop
-  runs by the ledger reader.
-- Sample via Thompson sampling on a Beta(1+n_accepts,
-  1+n_attempts-n_accepts) prior, or UCB1 on the accept rate.
-- Cold-start: zero history → uniform sampling, identical to today.
+The Thompson sampler shipped 2026-05-01 treats every rule as an
+independent arm.  A natural upgrade is to share strength across
+rules that target the same heuristic class (one `Heuristic`-level
+posterior) or the same kind (`log_uniform_perturb` posteriors borrow
+strength across all classes).  Particularly valuable when the
+catalog grows beyond a handful of rules and per-rule data is sparse.
+Implementation: replace the flat `Dict[RuleKey, Stats]` with a
+hierarchical Beta-Binomial or Dirichlet-Multinomial prior; expose
+the grouping policy via the catalog itself.
 
 #### Stratified dimension sampling (§10 stability)
 

--- a/scripts/self_improve.py
+++ b/scripts/self_improve.py
@@ -37,6 +37,16 @@ Two subcommands:
 
         uv run python scripts/self_improve.py summary
 
+``--adaptive``
+    Enable Thompson-sampling adaptive mutation sampler (§10 of the
+    plan).  The loop maintains a Beta posterior per rule and biases
+    future samples toward rules with positive accept history.  Cold-start
+    equivalent to uniform sampling.  Add ``--adaptive-prime-from-ledger``
+    to seed history from a prior ledger when resuming a long run::
+
+        uv run python scripts/self_improve.py run --iterations 50 \\
+            --adaptive --adaptive-prime-from-ledger
+
 Stop the loop early by ``touch STOP_SELF_IMPROVE`` (configurable via
 ``--stop-sentinel``); the current iteration will finish, then the loop
 exits and the ledger is preserved.
@@ -181,6 +191,38 @@ def _build_parser() -> argparse.ArgumentParser:
         default=1_000_000,
         help="Iteration-id offset for the guard's fresh seed (default: 1_000_000)",
     )
+    run_p.add_argument(
+        "--adaptive",
+        dest="adaptive_sampling",
+        action="store_true",
+        help=(
+            "Enable Thompson-sampling adaptive mutation sampler (§10): "
+            "the loop biases future iterations toward rules with positive accept history. "
+            "Cold-start equivalent to uniform sampling."
+        ),
+    )
+    run_p.set_defaults(adaptive_sampling=False)
+    run_p.add_argument(
+        "--adaptive-prior-alpha",
+        dest="adaptive_prior_alpha",
+        type=float,
+        default=1.0,
+        help="Beta prior alpha for the adaptive sampler (default: 1.0)",
+    )
+    run_p.add_argument(
+        "--adaptive-prior-beta",
+        dest="adaptive_prior_beta",
+        type=float,
+        default=1.0,
+        help="Beta prior beta for the adaptive sampler (default: 1.0)",
+    )
+    run_p.add_argument(
+        "--adaptive-prime-from-ledger",
+        dest="adaptive_prime_from_ledger",
+        action="store_true",
+        help="Seed adaptive sampler history from the existing ledger before running",
+    )
+    run_p.set_defaults(adaptive_prime_from_ledger=False)
     run_p.add_argument("--quiet", "-q", action="store_true", help="Suppress per-iteration output")
     run_p.set_defaults(func=_cmd_run)
 
@@ -219,14 +261,26 @@ def _cmd_run(args: argparse.Namespace) -> int:
         guard_interval=args.guard_interval,
         guard_eps_ladder=args.guard_eps_ladder,
         guard_iteration_offset=args.guard_iteration_offset,
+        adaptive_sampling=args.adaptive_sampling,
+        adaptive_prior_alpha=args.adaptive_prior_alpha,
+        adaptive_prior_beta=args.adaptive_prior_beta,
+        adaptive_prime_from_ledger=args.adaptive_prime_from_ledger,
     )
-    records = SelfImprover(cfg).run(verbose=not args.quiet)
+    improver = SelfImprover(cfg)
+    records = improver.run(verbose=not args.quiet)
 
     n_accepts = sum(1 for r in records if r.accepted)
     n_skips = sum(1 for r in records if r.proposal is None)
     n_total = len(records)
     print()
     print(f"[self_improve] completed: {n_total} iter, {n_accepts} accept, {n_skips} skip, ledger={cfg.ledger_path}")
+    if improver.sampler is not None:
+        snap = improver.sampler.stats_snapshot()
+        if snap:
+            print("[self_improve] adaptive sampler stats (class.param[kind] -> n_accepts/n_attempts):")
+            for s in snap:
+                cls, param, kind = s.rule_key
+                print(f"  {cls}.{param}[{kind}] -> {s.n_accepts}/{s.n_attempts} ({s.accept_rate:.0%})")
     return 0
 
 

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -53,6 +53,7 @@ from panobbgo.harness import (
     RunRecord,
 )
 from panobbgo.self_improve import (
+    AdaptiveMutationSampler,
     LadderEntry,
     LoopConfig,
     LoopGuardRecord,
@@ -60,6 +61,7 @@ from panobbgo.self_improve import (
     MutationCatalog,
     MutationProposal,
     MutationRule,
+    MutationRuleStats,
     SelfImprover,
     apply_mutation,
     default_catalog,
@@ -972,3 +974,397 @@ class TestLadderEntry:
         assert e.iteration == -1
         assert np.isnan(e.last_validated_score)
         assert e.proposal is None
+
+
+# ===========================================================================
+# AdaptiveMutationSampler (Thompson sampling)
+# ===========================================================================
+
+
+def _two_rule_catalog() -> MutationCatalog:
+    """Two rules pointing at independent kwargs in :func:`_make_specs`."""
+    return MutationCatalog(
+        [
+            MutationRule(
+                strategy_pattern="",
+                class_name="_DummyHeuristicA",
+                param_name="radius",
+                kind="log_uniform_perturb",
+                bounds=(0.005, 0.5),
+            ),
+            MutationRule(
+                strategy_pattern="",
+                class_name="_DummyHeuristicB",
+                param_name="sigma0",
+                kind="log_uniform_perturb",
+                bounds=(0.05, 1.0),
+            ),
+        ]
+    )
+
+
+class TestAdaptiveMutationSampler:
+    def test_invalid_priors_raise(self):
+        cat = _two_rule_catalog()
+        with pytest.raises(ValueError, match="prior_alpha and prior_beta"):
+            AdaptiveMutationSampler(cat, prior_alpha=0.0)
+        with pytest.raises(ValueError, match="prior_alpha and prior_beta"):
+            AdaptiveMutationSampler(cat, prior_beta=-1.0)
+
+    def test_cold_start_returns_proposals(self):
+        """A fresh sampler must successfully produce proposals."""
+        samp = AdaptiveMutationSampler(_two_rule_catalog())
+        rng = np.random.default_rng(0)
+        for _ in range(5):
+            prop = samp.sample(rng, _make_specs())
+            assert prop is not None
+            assert prop.class_name in {"_DummyHeuristicA", "_DummyHeuristicB"}
+
+    def test_returns_none_when_no_applicable_rules(self):
+        cat = MutationCatalog(
+            [
+                MutationRule(
+                    strategy_pattern="",
+                    class_name="DoesNotExist",
+                    param_name="x",
+                    kind="float_uniform",
+                    bounds=(0.0, 1.0),
+                ),
+            ]
+        )
+        samp = AdaptiveMutationSampler(cat)
+        rng = np.random.default_rng(0)
+        assert samp.sample(rng, _make_specs()) is None
+        # ``last_rule_key`` is reset so a stray record_outcome is a no-op.
+        assert samp.last_rule_key is None
+        samp.record_outcome(True)  # must not raise
+        assert samp.stats_snapshot() == []
+
+    def test_record_outcome_increments_stats(self):
+        samp = AdaptiveMutationSampler(_two_rule_catalog())
+        rng = np.random.default_rng(0)
+        for _ in range(10):
+            samp.sample(rng, _make_specs())
+            samp.record_outcome(True)
+        total_attempts = sum(s.n_attempts for s in samp.stats_snapshot())
+        total_accepts = sum(s.n_accepts for s in samp.stats_snapshot())
+        assert total_attempts == 10
+        assert total_accepts == 10
+
+    def test_record_outcome_no_op_after_none_sample(self):
+        samp = AdaptiveMutationSampler(_two_rule_catalog())
+        # Without a prior sample(), record is a no-op.
+        samp.record_outcome(True)
+        assert samp.stats_snapshot() == []
+
+    def test_thompson_biases_toward_winning_rule(self):
+        """If one rule always accepts and the other always rejects,
+        post-training samples must heavily favor the winning rule.
+
+        This is the headline guarantee of Thompson sampling: the bandit
+        must concentrate probability on the empirically better arm.
+        """
+        cat = _two_rule_catalog()
+        samp = AdaptiveMutationSampler(cat)
+        rng = np.random.default_rng(123)
+
+        # Train: A accepts, B rejects.
+        for _ in range(50):
+            prop = samp.sample(rng, _make_specs())
+            assert prop is not None
+            samp.record_outcome(prop.class_name == "_DummyHeuristicA")
+
+        # Now count picks over a fresh sampling phase (record_outcome
+        # disabled so stats freeze).
+        counts = {"_DummyHeuristicA": 0, "_DummyHeuristicB": 0}
+        for _ in range(500):
+            prop = samp.sample(rng, _make_specs())
+            assert prop is not None
+            counts[prop.class_name] += 1
+            # Reset last_rule_key without recording.
+            samp._last_rule_key = None
+
+        assert counts["_DummyHeuristicA"] > 4 * counts["_DummyHeuristicB"], (
+            f"Thompson should heavily favor the winning rule, got {counts}"
+        )
+
+    def test_uniform_prior_matches_uniform_sampler_distribution(self):
+        """Beta(1, 1) cold-start must distribute over rules ~uniformly.
+
+        Statistical, not deterministic: the difference between the two
+        counts should be small relative to the total over many draws.
+        """
+        cat = _two_rule_catalog()
+        samp = AdaptiveMutationSampler(cat, prior_alpha=1.0, prior_beta=1.0)
+        rng = np.random.default_rng(7)
+
+        counts = {"_DummyHeuristicA": 0, "_DummyHeuristicB": 0}
+        for _ in range(1000):
+            prop = samp.sample(rng, _make_specs())
+            counts[prop.class_name] += 1
+            # Don't record any outcomes — keep posterior at the prior.
+            samp._last_rule_key = None
+
+        # Both buckets should be roughly equal under U(0, 1) arg-max.
+        # Tolerance ±10% generous against rng quirks.
+        a, b = counts["_DummyHeuristicA"], counts["_DummyHeuristicB"]
+        ratio = a / (a + b)
+        assert 0.4 <= ratio <= 0.6, f"Expected near-uniform split, got {counts}"
+
+    def test_stats_snapshot_is_sorted(self):
+        samp = AdaptiveMutationSampler(_two_rule_catalog())
+        rng = np.random.default_rng(0)
+        for _ in range(20):
+            samp.sample(rng, _make_specs())
+            samp.record_outcome(True)
+        snap = samp.stats_snapshot()
+        keys = [s.rule_key for s in snap]
+        assert keys == sorted(keys)
+
+    def test_rule_stats_to_dict_round_trip(self):
+        s = MutationRuleStats(rule_key=("Foo", "bar", "log_uniform_perturb"), n_attempts=4, n_accepts=1)
+        d = s.to_dict()
+        assert d["class_name"] == "Foo"
+        assert d["accept_rate"] == pytest.approx(0.25)
+        # JSON serialisable.
+        assert json.loads(json.dumps(d))
+
+    def test_accept_rate_zero_when_no_attempts(self):
+        s = MutationRuleStats(rule_key=("A", "b", "kind"))
+        assert s.accept_rate == 0.0
+
+    def test_prime_from_ledger_replays_history(self, tmp_path):
+        """Iteration records must be replayed; guards / skips ignored."""
+        ledger = tmp_path / "old.jsonl"
+        # Two iteration records (one accept), one skip, one guard.
+        records = [
+            {
+                "record_type": "iteration",
+                "iteration": 0,
+                "proposal": {
+                    "class_name": "_DummyHeuristicA",
+                    "param_name": "radius",
+                    "rule_kind": "log_uniform_perturb",
+                },
+                "accepted": True,
+            },
+            {
+                "record_type": "iteration",
+                "iteration": 1,
+                "proposal": {
+                    "class_name": "_DummyHeuristicA",
+                    "param_name": "radius",
+                    "rule_kind": "log_uniform_perturb",
+                },
+                "accepted": False,
+            },
+            {
+                "record_type": "iteration",
+                "iteration": 2,
+                "proposal": None,
+                "accepted": False,
+            },
+            {
+                "record_type": "guard",
+                "iteration": 2,
+                "rolled_back": False,
+            },
+        ]
+        ledger.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+        samp = AdaptiveMutationSampler(_two_rule_catalog())
+        consumed = samp.prime_from_ledger(str(ledger))
+        # Only the two iteration records with non-null proposals count.
+        assert consumed == 2
+        snap = samp.stats_snapshot()
+        assert len(snap) == 1
+        assert snap[0].n_attempts == 2
+        assert snap[0].n_accepts == 1
+        assert snap[0].rule_key == ("_DummyHeuristicA", "radius", "log_uniform_perturb")
+
+    def test_prime_from_ledger_missing_file_returns_zero(self, tmp_path):
+        samp = AdaptiveMutationSampler(_two_rule_catalog())
+        consumed = samp.prime_from_ledger(str(tmp_path / "nope.jsonl"))
+        assert consumed == 0
+        assert samp.stats_snapshot() == []
+
+    def test_proposal_rationale_includes_thompson_marker(self):
+        samp = AdaptiveMutationSampler(_two_rule_catalog())
+        rng = np.random.default_rng(0)
+        prop = samp.sample(rng, _make_specs())
+        assert prop is not None
+        assert "Thompson" in prop.rationale
+
+
+# ===========================================================================
+# SelfImprover wired with the adaptive sampler
+# ===========================================================================
+
+
+class TestSelfImproverAdaptive:
+    def _accept_catalog(self) -> MutationCatalog:
+        return MutationCatalog(
+            [
+                MutationRule(
+                    strategy_pattern="",
+                    class_name="_DummyHeuristicA",
+                    param_name="radius",
+                    kind="log_uniform_perturb",
+                    bounds=(0.005, 0.5),
+                ),
+            ]
+        )
+
+    def test_adaptive_off_by_default(self, tmp_path):
+        cfg = LoopConfig(
+            iterations=0,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+        )
+        si = SelfImprover(cfg, seed_strategies=_make_specs())
+        assert si.sampler is None
+
+    def test_adaptive_creates_sampler(self, tmp_path):
+        cfg = LoopConfig(
+            iterations=0,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+            adaptive_sampling=True,
+        )
+        si = SelfImprover(cfg, seed_strategies=_make_specs())
+        assert isinstance(si.sampler, AdaptiveMutationSampler)
+        assert si.sampler.prior_alpha == 1.0
+        assert si.sampler.prior_beta == 1.0
+
+    def test_adaptive_propagates_priors(self, tmp_path):
+        cfg = LoopConfig(
+            iterations=0,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+            adaptive_sampling=True,
+            adaptive_prior_alpha=2.5,
+            adaptive_prior_beta=0.5,
+        )
+        si = SelfImprover(cfg, seed_strategies=_make_specs())
+        assert si.sampler is not None
+        assert si.sampler.prior_alpha == 2.5
+        assert si.sampler.prior_beta == 0.5
+
+    def test_adaptive_prime_from_ledger(self, tmp_path):
+        ledger = tmp_path / "ledger.jsonl"
+        # Pre-populate ledger with one accepted iteration on the catalog rule.
+        ledger.write_text(
+            json.dumps(
+                {
+                    "record_type": "iteration",
+                    "proposal": {
+                        "class_name": "_DummyHeuristicA",
+                        "param_name": "radius",
+                        "rule_kind": "log_uniform_perturb",
+                    },
+                    "accepted": True,
+                }
+            )
+            + "\n"
+        )
+        cfg = LoopConfig(
+            iterations=0,
+            ledger_path=str(ledger),
+            stop_sentinel_path="",
+            randomize=False,
+            adaptive_sampling=True,
+            adaptive_prime_from_ledger=True,
+        )
+        si = SelfImprover(cfg, catalog=self._accept_catalog(), seed_strategies=_make_specs())
+        assert si.sampler is not None
+        snap = si.sampler.stats_snapshot()
+        assert len(snap) == 1
+        assert snap[0].n_attempts == 1
+        assert snap[0].n_accepts == 1
+
+    def test_adaptive_sampler_records_outcomes(self, tmp_path):
+        """One iteration with adaptive sampling must update the sampler stats."""
+        # Each call returns 0.3 then 0.8 — so the candidate is much better.
+        counter = {"n": 0}
+
+        def score_fn(config: HarnessConfig) -> float:
+            n = counter["n"]
+            counter["n"] += 1
+            return 0.3 if n % 2 == 0 else 0.8
+
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=100,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+            adaptive_sampling=True,
+        )
+        si = SelfImprover(cfg, catalog=self._accept_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(score_fn)
+        records = si.run()
+        assert records[0].accepted is True
+        assert si.sampler is not None
+        snap = si.sampler.stats_snapshot()
+        assert len(snap) == 1
+        assert snap[0].n_attempts == 1
+        assert snap[0].n_accepts == 1
+
+    def test_adaptive_sampler_records_rejects(self, tmp_path):
+        """Reject paths must increment n_attempts but not n_accepts."""
+
+        # Constant score — no improvement so iteration rejects.
+        def score_fn(config: HarnessConfig) -> float:
+            return 0.5
+
+        cfg = LoopConfig(
+            iterations=2,
+            n_boot=100,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+            adaptive_sampling=True,
+        )
+        si = SelfImprover(cfg, catalog=self._accept_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(score_fn)
+        si.run()
+        assert si.sampler is not None
+        snap = si.sampler.stats_snapshot()
+        assert len(snap) == 1
+        assert snap[0].n_attempts == 2
+        assert snap[0].n_accepts == 0
+
+    def test_explicit_sampler_overrides_config(self, tmp_path):
+        """Passing ``sampler=`` must take priority over ``adaptive_sampling``."""
+        cat = self._accept_catalog()
+        explicit = AdaptiveMutationSampler(cat, prior_alpha=4.0, prior_beta=4.0)
+        cfg = LoopConfig(
+            iterations=0,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+            adaptive_sampling=False,  # explicit sampler should still win
+        )
+        si = SelfImprover(cfg, catalog=cat, sampler=explicit, seed_strategies=_make_specs())
+        assert si.sampler is explicit
+        assert si.sampler.prior_alpha == 4.0
+
+
+class TestLoopConfigAdaptive:
+    def test_invalid_prior_alpha_raises(self):
+        with pytest.raises(ValueError, match="adaptive_prior_alpha"):
+            LoopConfig(adaptive_prior_alpha=0.0)
+
+    def test_invalid_prior_beta_raises(self):
+        with pytest.raises(ValueError, match="adaptive_prior_beta"):
+            LoopConfig(adaptive_prior_beta=-1.0)
+
+    def test_defaults(self):
+        cfg = LoopConfig()
+        assert cfg.adaptive_sampling is False
+        assert cfg.adaptive_prior_alpha == 1.0
+        assert cfg.adaptive_prior_beta == 1.0
+        assert cfg.adaptive_prime_from_ledger is False


### PR DESCRIPTION
## Summary

Closes the §10 *Adaptive mutation sampler* item in
`planning/SELF_IMPROVEMENT_LOOP.md`.  The Phase-5 loop driver shipped
with a uniform sampler over `MutationCatalog` rules, which wastes
iterations on rules that never produce accepts.  This PR introduces
`AdaptiveMutationSampler` — a Thompson-sampling bandit over per-rule
Beta posteriors — with **cold-start equivalence to the uniform
sampler**, so the upgrade is strictly safe.

### What changes

- **`AdaptiveMutationSampler`** treats each `MutationRule` as a Bernoulli
  arm whose reward is "iteration was accepted".  On every `sample()`:
  draws one variate from `Beta(prior_alpha + n_accepts, prior_beta + n_attempts - n_accepts)`
  per applicable rule and picks the arg-max.  Inside the chosen rule, the
  concrete hit is still selected uniformly (which spec / which slot).
- **`LoopConfig`** gains `adaptive_sampling`, `adaptive_prior_alpha`,
  `adaptive_prior_beta`, `adaptive_prime_from_ledger`; all default to off
  / symmetric prior so existing CLI invocations are byte-identical.
  `prime_from_ledger()` replays accept history from a prior JSONL ledger
  so unattended multi-hour loops resume with their meta-knowledge intact.
- **`scripts/self_improve.py`** gains `--adaptive`,
  `--adaptive-prior-alpha`, `--adaptive-prior-beta`,
  `--adaptive-prime-from-ledger` flags; the run summary prints per-rule
  accept rates when adaptive sampling is on.

### Cold-start safety

With the default symmetric prior `Beta(1, 1)`, every posterior is `U(0, 1)`
and the arg-max of i.i.d. uniforms is itself uniform.  A test
(`test_uniform_prior_matches_uniform_sampler_distribution`) verifies a
near-50/50 split over 1000 cold-start samples on a two-rule catalog.

### Tests

23 new tests in `tests/test_self_improve.py` (total **63**, all green):
- invalid priors, cold-start equivalence to uniform sampling,
  arg-max bias toward winning rules after biased training,
- record-outcome correctness including no-op after `None` sample / skip
  iterations,
- ledger priming with guards / skips correctly ignored,
- `MutationRuleStats` round-trip,
- `SelfImprover` integration with the `sampler=` override and the
  `adaptive_prime_from_ledger` flag,
- `LoopConfig` validation for the new fields.

### Documentation

- `planning/SELF_IMPROVEMENT_LOOP.md`: §6 Phase-6 checklist marked shipped;
  new §12 dated entry; *Next iteration ideas* reduced and gains a
  hierarchical-bandit follow-up ticket.
- `doc/source/guide_benchmarking.rst`: new *Adaptive mutation sampler (§10)*
  subsection with algorithm, CLI examples, programmatic example, and
  cold-start equivalence proof sketch.
- `AGENTS.md`: self-improvement loop subsection lists the adaptive sampler
  with run-the-loop bash example.
- `TODO.md`: dated entry summarising the change.

## Test plan

- [x] `uv run pytest tests/test_self_improve.py -v` — 63 / 63 green.
- [x] `uv run pytest tests/ -q` — full suite **802 passed, 1 skipped**.
- [x] `uv run ruff format --check .` — clean.
- [x] `uv run pyright panobbgo/self_improve.py` — 0 errors.
- [x] `uv run sphinx-build -b doctest doc/source doc/build/doctest` — 96 doctests passed.
- [x] CLI smoke test: `scripts/self_improve.py run --iterations 2 --adaptive`
      runs end-to-end and reports per-rule accept stats.

https://claude.ai/code/session_01Y8dcZdQf8q9SZMpmZxMEo8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8dcZdQf8q9SZMpmZxMEo8)_