### PR TITLE
feat(harness_randomized): stratified dimension sampling (§10)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,16 @@ uv run python benchmark_harness.py compare rand_before.json rand_after.json --st
 reproduces the *same* sampled instances, so ``before`` and ``after`` runs
 line up; different iterations intentionally draw different instances.
 
+Multi-dim families (``dim_choices`` with more than one element) ship with
+``stratify_dims=True`` by default, so the dim assigned to rep ``i`` is
+``dim_choices[i % k]`` — any contiguous block of ``k`` reps covers every
+declared dim exactly once.  This eliminates dim-mix variance in the
+composite delta (the bootstrap CI from ``--statistical`` would otherwise
+pick up the noise of "this iteration happened to draw more 5-D
+instances").  Single-dim families (the entire default battery) are
+unaffected.  See :class:`panobbgo.harness_randomized.ProblemFamily` and
+``planning/SELF_IMPROVEMENT_LOOP.md`` §10.
+
 ### Key files
 
 *   `panobbgo/harness.py` — `BenchmarkHarness` class, metrics, serialization, `compare()`, and `statistical_accept()` (bootstrap-CI acceptance rule)

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,58 @@
 
 ## Recent Improvements (continued)
 
+### Stratified Dimension Sampling for Multi-Dim Families (2026-05-02)
+- [x] **`panobbgo.harness_randomized.ProblemFamily.stratify_dims`** —
+      new bool field (default ``True``) that enables cyclic dim
+      stratification for multi-dim families.  Closes the §10 "Composite
+      score stability across dimension sampling" open question in
+      `planning/SELF_IMPROVEMENT_LOOP.md`.
+- [x] **`ProblemFamily.stratified_dim_for_rep(rep)`** — returns
+      ``dim_choices[rep % len(dim_choices)]``, so any contiguous block
+      of ``k`` reps covers every declared dim exactly once.
+- [x] **`ProblemFamily.sample_instance(rng, dim=None)`** — now accepts
+      an optional dim override.  Stratified callers pin the dim
+      explicitly, so the rng's ``choice`` slot is not consumed and the
+      remaining stream (translation, rotation, scaling, noise seed)
+      stays comparable to a single-dim family at the same seed.
+- [x] **`RandomizedProblemSpec.create_problem_for_rep(rep)`** — calls
+      ``stratified_dim_for_rep(rep)`` for multi-dim families with
+      ``stratify_dims=True`` and falls back to the rng draw otherwise.
+      ``last_sampled_params()`` now exposes a ``stratified_dim: bool``
+      flag for ledger introspection.
+- [x] **Why it matters.** Without stratification, a family with
+      ``dim_choices = (2, 5, 10)`` and 5 reps could draw three ``dim=2``
+      instances on iteration 5 and three ``dim=10`` instances on
+      iteration 6.  Higher-dim instances are systematically harder, so
+      a per-iteration composite delta picks up dim-mix noise on top of
+      the actual signal of the underlying mutation, polluting the
+      bootstrap CI in :func:`panobbgo.harness.statistical_accept`.
+      Cyclic stratification eliminates that noise source by construction
+      without changing the per-iteration eval count.
+- [x] **Backwards compatibility.** The entire default battery from
+      :func:`make_default_families` uses ``dim_choices=(2,)``, so
+      stratification is a no-op for byte-level reproducibility of the
+      current standard mode.  ``stratify_dims=False`` recovers the
+      legacy uniform-draw behaviour for users replicating an old ledger.
+- [x] **16 new tests in `tests/test_harness_randomized.py`** (total 68):
+      cyclic schedule correctness, balance over a complete cycle,
+      imbalance bound on partial cycles, single-dim no-op, dim-override
+      validation, rng-stream invariance proof (override does not consume
+      the choice slot), end-to-end :class:`RandomizedProblemSpec` round
+      trip, ``last_sampled_params`` flag round trip, and the contract
+      that default families remain unchanged.
+- [x] **Documentation updated**
+  - `planning/SELF_IMPROVEMENT_LOOP.md`: §10 stability item resolved;
+    Phase 6 checklist updated; new §12 dated entry under iteration log;
+    stratification clause added to the §4.1 transforms table; Next
+    iteration ideas now lists a "multi-dim default battery" follow-up.
+  - `doc/source/guide_benchmarking.rst`: new "Stratified dimension
+    sampling" subsection with the cyclic schedule example and the
+    ``stratify_dims=False`` escape hatch.
+  - `AGENTS.md`: stratification clause in the parametric battery
+    section.
+  - This TODO entry.
+
 ### Adaptive Mutation Sampler (Thompson Sampling) for Self-Improvement Loop (2026-05-01)
 - [x] **New `panobbgo.self_improve.AdaptiveMutationSampler`** — Thompson-
       sampling bandit over per-rule Beta posteriors; closes the §10

--- a/doc/source/guide_benchmarking.rst
+++ b/doc/source/guide_benchmarking.rst
@@ -364,6 +364,43 @@ Schwefel's optimum sits near the box boundary and Griewank's oscillation
 couples tightly to the coordinate axes, so rotation pushes ``y`` off the
 function's sensible domain.
 
+Stratified dimension sampling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a :class:`~panobbgo.harness_randomized.ProblemFamily` declares
+``dim_choices = (2, 5, 10)``, naive random selection would produce a
+different mix of dimensions on each loop iteration — and since
+higher-dim instances are systematically harder, that mix-noise
+contaminates the cross-iteration deltas the bootstrap CI in
+:func:`panobbgo.harness.statistical_accept` (§6.2 of the
+self-improvement loop) operates on.
+
+The default ``stratify_dims=True`` flag eliminates that noise source by
+construction.
+:meth:`~panobbgo.harness_randomized.ProblemFamily.stratified_dim_for_rep`
+assigns the dim **cyclically** by repetition index so any contiguous
+block of ``len(dim_choices)`` reps covers every declared dim exactly
+once:
+
+.. code-block:: python
+
+   from panobbgo.harness_randomized import ProblemFamily
+   from panobbgo.lib.classic import DeJong
+
+   fam = ProblemFamily(name="dejong3", base_class=DeJong,
+                       dim_choices=(2, 5, 10))  # stratify_dims=True
+   [fam.stratified_dim_for_rep(rep) for rep in range(7)]
+   # → [2, 5, 10, 2, 5, 10, 2]
+
+When the family's dim-choice tuple has only one element (the default
+battery), stratification is a no-op and the per-rep dim is constant.
+For backwards compatibility with older ledgers, set
+``stratify_dims=False`` to recover the legacy uniform-draw behaviour.
+
+The result of a stratified sample is reflected in
+``RandomizedProblemSpec.last_sampled_params()`` via a
+``stratified_dim: bool`` field, useful for ledger introspection.
+
 Reproducibility
 ~~~~~~~~~~~~~~~
 

--- a/panobbgo/harness_randomized.py
+++ b/panobbgo/harness_randomized.py
@@ -393,6 +393,16 @@ class ProblemFamily:
         dim_choices: Dimensions the sampler may draw from.  Using a single
             dimension gives a stratified battery; a multi-element tuple
             samples a dimension per instance.
+        stratify_dims: When ``True`` (default) and ``len(dim_choices) > 1``,
+            :class:`RandomizedProblemSpec` assigns dims **cyclically** by
+            ``rep`` (rep ``i`` gets ``dim_choices[i % k]``) so any
+            contiguous block of ``k`` reps covers every dim exactly once.
+            This eliminates dim-mix variance across iterations of the
+            self-improvement loop — see §10 of
+            ``planning/SELF_IMPROVEMENT_LOOP.md``.  When ``False``, the
+            dim is drawn uniformly from ``dim_choices`` per instance,
+            which dilutes cross-iteration deltas with sampling noise.
+            Single-dim families are unaffected by this flag.
         supported_transforms: Subset of :data:`SUPPORTED_TRANSFORMS`.
         tolerance: Success tolerance for ``func_distance`` in the harness.
         log10_cond_max: Ceiling on :math:`\\log_{10} \\kappa` when
@@ -410,6 +420,7 @@ class ProblemFamily:
     y_base_star: Optional[Sequence[float]] = None
     f_opt: float = 0.0
     dim_choices: Tuple[int, ...] = (2,)
+    stratify_dims: bool = True
     supported_transforms: Set[str] = field(default_factory=lambda: {"translate", "rotate", "scale"})
     tolerance: float = 0.1
     log10_cond_max: float = 2.0
@@ -428,10 +439,47 @@ class ProblemFamily:
             return self.base_factory(dim, rng)
         return self.base_class(dims=dim)
 
-    def sample_instance(self, rng: np.random.Generator) -> Tuple[TransformedProblem, Dict[str, Any]]:
-        """Draw one transformed instance and its parameter record."""
+    def stratified_dim_for_rep(self, rep: int) -> int:
+        """Return the dim assigned to rep ``rep`` under cyclic stratification.
+
+        Cycles through :attr:`dim_choices` so that any contiguous block of
+        ``len(dim_choices)`` reps covers every declared dimension exactly
+        once.  When ``len(dim_choices) == 1`` the result is the constant
+        family dim.  See §10 of ``planning/SELF_IMPROVEMENT_LOOP.md``.
+
+        Args:
+            rep: Non-negative repetition index.
+
+        Returns:
+            The assigned dim as a Python ``int``.
+        """
+        if rep < 0:
+            raise ValueError(f"rep must be non-negative, got {rep}")
+        return int(self.dim_choices[rep % len(self.dim_choices)])
+
+    def sample_instance(
+        self,
+        rng: np.random.Generator,
+        dim: Optional[int] = None,
+    ) -> Tuple[TransformedProblem, Dict[str, Any]]:
+        """Draw one transformed instance and its parameter record.
+
+        Args:
+            rng: Numpy generator used for *all* random choices in this
+                instance (translation, rotation, scaling, noise seed).
+            dim: Optional dimension override.  When ``None`` (default),
+                the dim is drawn from :attr:`dim_choices` (constant for
+                single-dim families, uniform draw for multi-dim).
+                Stratified callers (e.g. :class:`RandomizedProblemSpec`)
+                pass an explicit dim so the rng is not consumed by the
+                dim choice and the stratified schedule is honoured.
+        """
         # Choose a dimension.
-        if len(self.dim_choices) == 1:
+        if dim is not None:
+            dim = int(dim)
+            if dim not in self.dim_choices:
+                raise ValueError(f"family {self.name!r}: dim={dim} is not in dim_choices={self.dim_choices}")
+        elif len(self.dim_choices) == 1:
             dim = int(self.dim_choices[0])
         else:
             dim = int(rng.choice(self.dim_choices))
@@ -553,12 +601,23 @@ class RandomizedProblemSpec(ProblemSpec):
         )
 
     def create_problem_for_rep(self, rep: int) -> TransformedProblem:
-        """Sample a fresh instance for the given repetition."""
+        """Sample a fresh instance for the given repetition.
+
+        For multi-dim families with :attr:`ProblemFamily.stratify_dims`
+        enabled, the dim is assigned cyclically by ``rep`` so any
+        contiguous block of ``len(dim_choices)`` reps covers every
+        declared dim exactly once.  Single-dim families are unaffected.
+        """
         seed = derive_instance_seed(self.base_seed, self.iteration_id, self.family.name, rep)
         rng = np.random.default_rng(seed)
-        problem, params = self.family.sample_instance(rng)
+        if self.family.stratify_dims and len(self.family.dim_choices) > 1:
+            dim_override: Optional[int] = self.family.stratified_dim_for_rep(rep)
+        else:
+            dim_override = None
+        problem, params = self.family.sample_instance(rng, dim=dim_override)
         params["seed"] = seed
         params["rep"] = rep
+        params["stratified_dim"] = dim_override is not None
         self._last_sampled_params = params
         return problem
 

--- a/planning/SELF_IMPROVEMENT_LOOP.md
+++ b/planning/SELF_IMPROVEMENT_LOOP.md
@@ -110,7 +110,7 @@ Given a base problem `P` (e.g. Rastrigin), each harness run samples a
 | Rotation      | random orthogonal `Q ∈ O(d)`             | breaks axis-aligned local search advantage |
 | Scaling       | diagonal `Λ`, `log₁₀ cond ∼ U[0, 4]`     | stresses second-order / ill-conditioning   |
 | Noise         | `f̃(x) = f(x) + σ·ε`, `σ ∈ {0, 1e-3, 1e-2}` | matches noisy black-box use case           |
-| Dimension     | `d ∼ choice({2, 5, 10})`                 | prevents per-dim overfit                   |
+| Dimension     | cyclic stratification over `dim_choices` (rep `i` → `dim_choices[i % k]`) | prevents per-dim overfit *and* dim-mix variance — see §10 |
 | Box shift     | box translated with optimum              | the optimum is not at a corner             |
 
 Not every problem supports every transform (Schwefel's optimum is
@@ -387,8 +387,18 @@ Each phase is independently deliverable and keeps the framework usable.
       when resuming a long run.
 - [ ] Broaden the mutation space (strategy portfolio composition,
       analyzer add/drop — §7 items 2–3).
-- [ ] Stratified dimension sampling (§10) for cross-iteration score
-      stability.
+- [x] Stratified dimension sampling (§10) for cross-iteration score
+      stability — shipped 2026-05-02 as
+      :attr:`panobbgo.harness_randomized.ProblemFamily.stratify_dims`
+      (default ``True``) and
+      :meth:`ProblemFamily.stratified_dim_for_rep`.
+      :class:`RandomizedProblemSpec.create_problem_for_rep` now assigns
+      dims cyclically by ``rep`` (rep ``i`` → ``dim_choices[i % k]``)
+      so any contiguous block of ``k`` reps covers every dim exactly
+      once.  Single-dim families are unaffected.  Tests in
+      ``tests/test_harness_randomized.py::TestStratifiedDims`` /
+      ``TestStratifiedSampleInstance`` /
+      ``TestStratifiedRandomizedSpec``.
 - [ ] Connect the loop to CI (nightly run on a dedicated runner).
 - [ ] Publish the ladder in the docs.
 
@@ -409,7 +419,11 @@ Each phase is independently deliverable and keeps the framework usable.
 - **Composite score stability across dimension sampling.** If we sample
   `d ∈ {2, 5, 10}` we need to *stratify* (same mix of dimensions on both
   sides of the comparison) or the score will be dominated by whichever
-  dimension happened to be sampled more.
+  dimension happened to be sampled more.  **Resolved 2026-05-02** via
+  :attr:`panobbgo.harness_randomized.ProblemFamily.stratify_dims` —
+  multi-dim families now assign dims cyclically by ``rep`` so any
+  contiguous block of ``len(dim_choices)`` reps covers every declared
+  dim exactly once.  See the §12 entry below.
 - **Coordination with `simplify`, `review`, `security-review`.** The loop
   should not run alongside a human PR — race conditions on the branch
   would be ugly. A simple lockfile suffices.
@@ -435,6 +449,54 @@ This section records direct algorithmic improvements applied to Panobbgo
 *outside* of the autonomous loop, so the human-in-the-loop history stays
 greppable.  Each entry should reference the PR / commit that landed it,
 the rationale, and a measured-impact number when available.
+
+### 2026-05-02 — Stratified dimension sampling for multi-dim families
+
+* **What** — `panobbgo/harness_randomized.py`:
+  :class:`ProblemFamily` gains a ``stratify_dims: bool = True`` field and
+  a :meth:`stratified_dim_for_rep` helper that returns
+  ``dim_choices[rep % k]``.  :meth:`ProblemFamily.sample_instance` now
+  accepts an optional ``dim`` override so callers can pin the dim
+  without consuming the rng's ``choice`` slot.
+  :meth:`RandomizedProblemSpec.create_problem_for_rep` calls
+  ``stratified_dim_for_rep(rep)`` for multi-dim families with
+  ``stratify_dims=True`` (the default) and falls back to the rng's
+  ``choice`` otherwise.  ``last_sampled_params()`` now reports a
+  ``stratified_dim: bool`` flag for ledger introspection.
+* **Why** — closes the §10 *Composite score stability across dimension
+  sampling* item.  Without stratification, a multi-dim family with
+  ``dim_choices = (2, 5, 10)`` and 5 reps could draw, say, three
+  ``dim=2`` instances on iteration 5 and three ``dim=10`` instances on
+  iteration 6.  Higher-dim instances are systematically harder, so a
+  per-iteration composite delta picks up dim-mix noise on top of the
+  signal of the underlying mutation, polluting the bootstrap CI on
+  which §6.2 acceptance depends.  Cyclic stratification (rep ``i`` →
+  ``dim_choices[i % k]``) makes any contiguous block of ``k`` reps
+  cover every declared dim exactly once, eliminating that noise source
+  by construction without changing the per-iteration eval count.
+* **Impact** — purely a measurement-noise improvement: the default
+  battery of families all use ``dim_choices=(2,)`` (single dim), so
+  this change is a no-op for the byte-level reproducibility of the
+  current standard mode.  The benefit materialises when users (or the
+  loop) declare multi-dim families — e.g. via
+  ``HarnessConfig.extra_families`` — at which point the cross-iteration
+  variance of the composite drops by roughly ``Var(dim_mix)`` (the
+  fraction of total variance attributable to which dim was sampled,
+  typically a substantial slice for hard families like Rosenbrock).
+* **Backwards compatibility** — strictly safe.  Single-dim families
+  (the entire default battery) are unaffected because the cyclic
+  schedule degenerates to a constant.  The public :class:`ProblemFamily`
+  signature gains a new keyword-only field with a default; existing
+  ``ProblemFamily(...)`` callers keep working byte-identically.  The
+  ``stratify_dims=False`` path preserves the previous behaviour for
+  anyone who needs it (e.g. for replicating an old ledger).
+* **Tests** — `tests/test_harness_randomized.py` (16 new tests, total
+  68): cyclic schedule correctness, balance over a complete cycle,
+  imbalance bound on partial cycles, single-dim no-op, dim-override
+  validation, rng-stream invariance proof (override does not consume
+  the choice slot), end-to-end :class:`RandomizedProblemSpec` round
+  trip, ``last_sampled_params`` flag round trip, and the contract that
+  default families remain unchanged.
 
 ### 2026-05-01 — Adaptive mutation sampler (Thompson sampling)
 
@@ -544,14 +606,18 @@ Implementation: replace the flat `Dict[RuleKey, Stats]` with a
 hierarchical Beta-Binomial or Dirichlet-Multinomial prior; expose
 the grouping policy via the catalog itself.
 
-#### Stratified dimension sampling (§10 stability)
+#### Multi-dim default battery (now that stratification is shipped)
 
-When a `ProblemFamily` declares `dim_choices = (2, 5, 10)`, the current
-sampler draws one dim per instance.  Across iterations this dilutes the
-composite score with a different mix of dims each time, so
-cross-iteration deltas pick up dim-mix noise.  Stratify by running
-`ceil(reps / k)` reps per dim and averaging — same compute, much
-lower noise.
+Stratified dimension sampling shipped 2026-05-02.  The default battery
+in :func:`panobbgo.harness_randomized.make_default_families` still uses
+``dim_choices=(2,)`` everywhere because expanding it would shift the
+historical composite score baseline.  A natural follow-up is to add a
+``make_default_families_multidim()`` factory (or a `--dim-mix` CLI
+flag) that ships ``dim_choices=(2, 5, 10)`` for Rastrigin / Ackley /
+DeJong, exposing the new stratification and giving the loop a richer
+generalisation signal.  Needs an architectural decision record because
+the resulting composite is not directly comparable to the existing
+ladder.
 
 #### Strategy portfolio composition (§7.2)
 

--- a/tests/test_harness_randomized.py
+++ b/tests/test_harness_randomized.py
@@ -497,3 +497,209 @@ class TestHarnessRandomize:
         for fam in make_default_families():
             for t in fam.supported_transforms:
                 assert t in SUPPORTED_TRANSFORMS
+
+
+# ===========================================================================
+# 6. Stratified dimension sampling (§10 of SELF_IMPROVEMENT_LOOP.md)
+# ===========================================================================
+
+
+class TestStratifiedDims:
+    """``stratify_dims=True`` (the default) gives a balanced cyclic schedule.
+
+    Without stratification, multi-dim families inject dim-mix sampling
+    noise into cross-iteration deltas: a "lucky" iteration that happens to
+    draw extra reps at the easier dim looks better than a "lucky" iteration
+    that draws extra reps at the harder dim, even if the underlying optimizer
+    is unchanged.  Cyclic stratification (rep ``i`` gets ``dim_choices[i %
+    k]``) makes any contiguous block of ``k`` reps cover every declared dim
+    exactly once.
+    """
+
+    def test_default_is_stratified(self):
+        fam = ProblemFamily(name="multidim", base_class=DeJong, dim_choices=(2, 3, 5))
+        assert fam.stratify_dims is True
+
+    def test_stratified_dim_for_rep_cycles(self):
+        fam = ProblemFamily(name="multidim", base_class=DeJong, dim_choices=(2, 3, 5))
+        # Rep 0..2 covers every dim once; rep 3 wraps around to dim_choices[0].
+        assert fam.stratified_dim_for_rep(0) == 2
+        assert fam.stratified_dim_for_rep(1) == 3
+        assert fam.stratified_dim_for_rep(2) == 5
+        assert fam.stratified_dim_for_rep(3) == 2
+        assert fam.stratified_dim_for_rep(7) == 3
+
+    def test_stratified_dim_single_choice_constant(self):
+        fam = ProblemFamily(name="single", base_class=DeJong, dim_choices=(4,))
+        for rep in range(8):
+            assert fam.stratified_dim_for_rep(rep) == 4
+
+    def test_negative_rep_raises(self):
+        fam = ProblemFamily(name="multidim", base_class=DeJong, dim_choices=(2, 3))
+        with pytest.raises(ValueError):
+            fam.stratified_dim_for_rep(-1)
+
+    def test_balanced_distribution_over_block(self):
+        # A contiguous block of k*N reps covers every dim N times.
+        fam = ProblemFamily(name="multidim", base_class=DeJong, dim_choices=(2, 3, 5))
+        block_size = 12  # 4 cycles
+        from collections import Counter
+
+        counts = Counter(fam.stratified_dim_for_rep(rep) for rep in range(block_size))
+        assert counts[2] == 4
+        assert counts[3] == 4
+        assert counts[5] == 4
+
+    def test_partial_block_imbalance_at_most_one(self):
+        # If reps is not a multiple of k, the imbalance is at most 1.
+        fam = ProblemFamily(name="multidim", base_class=DeJong, dim_choices=(2, 3, 5))
+        from collections import Counter
+
+        counts = Counter(fam.stratified_dim_for_rep(rep) for rep in range(7))
+        assert max(counts.values()) - min(counts.values()) <= 1
+
+
+class TestStratifiedSampleInstance:
+    """``ProblemFamily.sample_instance`` accepts a ``dim`` override."""
+
+    def test_dim_override_honoured(self):
+        fam = ProblemFamily(name="multidim", base_class=DeJong, dim_choices=(2, 3, 5))
+        rng = np.random.default_rng(0)
+        prob, params = fam.sample_instance(rng, dim=5)
+        assert prob.dim == 5
+        assert params["dim"] == 5
+
+    def test_dim_override_must_be_in_choices(self):
+        fam = ProblemFamily(name="multidim", base_class=DeJong, dim_choices=(2, 3))
+        rng = np.random.default_rng(0)
+        with pytest.raises(ValueError, match="not in dim_choices"):
+            fam.sample_instance(rng, dim=4)
+
+    def test_no_override_uses_random_choice(self):
+        # With dim=None and multiple choices, the rng draws the dim.  Two
+        # different rngs with different streams yield (potentially) different
+        # dims; we just check that some dim from the choices is selected.
+        fam = ProblemFamily(name="multidim", base_class=DeJong, dim_choices=(2, 3, 5))
+        from collections import Counter
+
+        seen = Counter()
+        for s in range(40):
+            rng = np.random.default_rng(s)
+            _, params = fam.sample_instance(rng, dim=None)
+            seen[params["dim"]] += 1
+        # Every dim chosen at least once over 40 draws (probability ~ 1).
+        assert set(seen) == {2, 3, 5}
+
+    def test_override_does_not_consume_rng_for_dim_choice(self):
+        # When dim is provided, rng.choice(dim_choices) is not called, so the
+        # *remaining* sequence of random draws (translation, rotation, …)
+        # matches what you'd get from a fresh rng of the same seed when the
+        # family is single-dim.  Concretely: the first translation sample
+        # under (dim=2 override, dim_choices=(2, 3)) equals the translation
+        # sample under (dim_choices=(2,)) at the same seed.
+        fam_multi = ProblemFamily(
+            name="multi",
+            base_class=DeJong,
+            dim_choices=(2, 3),
+            supported_transforms={"translate"},
+        )
+        fam_single = ProblemFamily(
+            name="single",
+            base_class=DeJong,
+            dim_choices=(2,),
+            supported_transforms={"translate"},
+        )
+        rng_a = np.random.default_rng(42)
+        rng_b = np.random.default_rng(42)
+        _, params_a = fam_multi.sample_instance(rng_a, dim=2)
+        _, params_b = fam_single.sample_instance(rng_b, dim=None)
+        np.testing.assert_allclose(params_a["translation"], params_b["translation"])
+
+
+class TestStratifiedRandomizedSpec:
+    """End-to-end: ``RandomizedProblemSpec`` honours stratified scheduling."""
+
+    def _multi_family(self, stratify=True):
+        return ProblemFamily(
+            name="multi_dejong",
+            base_class=DeJong,
+            dim_choices=(2, 3, 5),
+            supported_transforms={"translate"},
+            stratify_dims=stratify,
+        )
+
+    def test_stratified_spec_assigns_dim_by_rep(self):
+        fam = self._multi_family(stratify=True)
+        spec = RandomizedProblemSpec(fam, iteration_id=0, base_seed=42, max_evaluations=100)
+        for rep, expected_dim in enumerate([2, 3, 5, 2, 3, 5]):
+            problem = spec.create_problem_for_rep(rep)
+            assert problem.dim == expected_dim
+            params = spec.last_sampled_params()
+            assert params is not None
+            assert params["dim"] == expected_dim
+            assert params["stratified_dim"] is True
+
+    def test_unstratified_spec_draws_from_rng(self):
+        # When stratify_dims is off, the dim is drawn from the rng (so it may
+        # repeat across consecutive reps) and the param flag is False.
+        fam = self._multi_family(stratify=False)
+        spec = RandomizedProblemSpec(fam, iteration_id=0, base_seed=42, max_evaluations=100)
+        dims_seen = []
+        for rep in range(20):
+            problem = spec.create_problem_for_rep(rep)
+            dims_seen.append(problem.dim)
+            params = spec.last_sampled_params()
+            assert params is not None
+            assert params["stratified_dim"] is False
+        # Every dim is drawn at least once over 20 reps (probability ~ 1).
+        assert set(dims_seen) == {2, 3, 5}
+
+    def test_stratified_balanced_over_block(self):
+        # A contiguous block of k reps covers every dim once.
+        fam = self._multi_family(stratify=True)
+        spec = RandomizedProblemSpec(fam, iteration_id=11, base_seed=42, max_evaluations=100)
+        from collections import Counter
+
+        counts = Counter(spec.create_problem_for_rep(rep).dim for rep in range(9))
+        assert counts == Counter({2: 3, 3: 3, 5: 3})
+
+    def test_stratified_reproducible_across_specs(self):
+        # The before/after contract still holds: identical iteration_id +
+        # rep gives identical instances.
+        fam = self._multi_family(stratify=True)
+        s1 = RandomizedProblemSpec(fam, iteration_id=5, base_seed=42, max_evaluations=100)
+        s2 = RandomizedProblemSpec(fam, iteration_id=5, base_seed=42, max_evaluations=100)
+        for rep in range(6):
+            p1 = s1.create_problem_for_rep(rep)
+            p2 = s2.create_problem_for_rep(rep)
+            assert p1.dim == p2.dim
+            np.testing.assert_allclose(p1.optimum, p2.optimum)
+
+    def test_single_dim_unaffected_by_flag(self):
+        # When the family has only one dim, stratify_dims is a no-op:
+        # every rep has the same dim and the flag is reported False because
+        # stratification is bypassed for trivial single-dim families.
+        fam = ProblemFamily(
+            name="single",
+            base_class=DeJong,
+            dim_choices=(3,),
+            supported_transforms={"translate"},
+            stratify_dims=True,
+        )
+        spec = RandomizedProblemSpec(fam, iteration_id=0, base_seed=42, max_evaluations=100)
+        for rep in range(4):
+            problem = spec.create_problem_for_rep(rep)
+            assert problem.dim == 3
+            params = spec.last_sampled_params()
+            assert params is not None
+            # No stratification scheduling for trivial single-dim families.
+            assert params["stratified_dim"] is False
+
+    def test_default_families_unchanged(self):
+        # All default families ship with single dim, so stratification is a
+        # no-op and the behaviour is identical to before this feature.
+        for fam in make_default_families():
+            assert len(fam.dim_choices) == 1
+            spec = RandomizedProblemSpec(fam, iteration_id=0, base_seed=42, max_evaluations=100)
+            problem = spec.create_problem_for_rep(0)
+            assert problem.dim == fam.dim_choices[0]


### PR DESCRIPTION
## Summary

Closes the §10 *Composite score stability across dimension sampling* open question in `planning/SELF_IMPROVEMENT_LOOP.md`.

Without stratification, a multi-dim family with `dim_choices = (2, 5, 10)` and 5 reps could draw three `dim=2` instances on iteration 5 and three `dim=10` instances on iteration 6.  Higher-dim instances are systematically harder, so a per-iteration composite delta picks up dim-mix noise on top of the actual signal of the underlying mutation, polluting the bootstrap CI in `panobbgo.harness.statistical_accept` (§6.2 acceptance).

The fix is **cyclic stratification**: rep `i` is assigned `dim_choices[i % k]`, so any contiguous block of `k` reps covers every declared dim exactly once.  This eliminates dim-mix variance by construction without changing the per-iteration eval count.

## Implementation

- `ProblemFamily` gains `stratify_dims: bool = True` and `stratified_dim_for_rep(rep)`.
- `ProblemFamily.sample_instance(rng, dim=None)` now accepts an optional dim override; stratified callers pin the dim explicitly so the rng's `choice` slot is not consumed and the remaining stream stays comparable to a single-dim family at the same seed.
- `RandomizedProblemSpec.create_problem_for_rep(rep)` calls `stratified_dim_for_rep(rep)` for multi-dim families with `stratify_dims=True` (the default) and falls back to the rng draw otherwise.  `last_sampled_params()` now exposes a `stratified_dim: bool` flag for ledger introspection.

## Backwards compatibility

The entire default battery from `make_default_families()` uses `dim_choices=(2,)` (single dim), so stratification is a **no-op** for byte-level reproducibility of the current standard mode.  `stratify_dims=False` recovers the legacy uniform-draw behaviour for users replicating an old ledger.

## Test plan

- [x] `uv run pytest tests/test_harness_randomized.py` — 68 tests pass (52 existing + 16 new).
- [x] `uv run pytest tests/` — full suite: 818 passed, 1 skipped.
- [x] `uv run ruff check panobbgo/ tests/` — clean.
- [x] `uv run ruff format --check .` — clean.
- [x] `uv run pyright panobbgo` — 0 errors.
- [x] `uv run sphinx-build -b doctest doc/source doc/build/doctest` — 96 doctests pass.
- [x] `timeout 60 uv run pytest benchmarks/` — 13 benchmarks pass.

## Tests added

16 new tests in `tests/test_harness_randomized.py`:

- `TestStratifiedDims`: cyclic schedule correctness, single-dim no-op, negative-rep guard, balance over a complete cycle, imbalance bound on partial cycles.
- `TestStratifiedSampleInstance`: dim override honoured, override validation, rng-stream invariance proof (override does not consume the choice slot), `dim=None` falls back to random draw.
- `TestStratifiedRandomizedSpec`: end-to-end `RandomizedProblemSpec` round trip, balanced distribution, before/after reproducibility contract, single-dim families unaffected, default battery unchanged.

## Documentation

- `planning/SELF_IMPROVEMENT_LOOP.md`: §10 stability item resolved, Phase 6 checklist updated, new §12 dated entry, stratification clause in §4.1 transforms table, "Next iteration ideas" now lists a multi-dim default battery follow-up (deferred because expanding the default battery would shift the historical composite ladder).
- `doc/source/guide_benchmarking.rst`: new "Stratified dimension sampling" subsection with the cyclic schedule example and the `stratify_dims=False` escape hatch.
- `AGENTS.md`: stratification clause in the parametric battery section.
- `TODO.md`: dated entry under Recent Improvements.

https://claude.ai/code/session_014S6WwVAWDrtMYfMLLJ2jvg

---
_Generated by [Claude Code](https://claude.ai/code/session_014S6WwVAWDrtMYfMLLJ2jvg)_