### PR TITLE
feat(self_improve): hold-out validation set (§10)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,16 @@ The harness is the measurement substrate for an autonomous
     `scripts/self_improve.py run --structural` or
     `SelfImprover(catalog=default_structural_catalog())`.  Off by
     default so existing CLI invocations remain byte-identical.
+*   Hold-out validation set — **shipped** (§10), see
+    `panobbgo.self_improve.LoopHoldoutRecord` and the
+    `--holdout-base-seed`, `--holdout-iterations`,
+    `--holdout-iteration-offset`, `--holdout-eps-overfit`,
+    `--fail-on-overfit` CLI flags.  At the end of every loop run, the
+    seed and final-top of the ladder are re-measured on instances
+    drawn from a completely independent ``base_seed`` SHA-256 stream;
+    a shrinking ``top - seed`` gap (``drift < -eps_overfit``) flags
+    overfit to the training base_seed family — the failure mode the
+    anti-cherry-pick guard cannot see.
 
 Run the loop:
 
@@ -258,6 +268,11 @@ uv run python scripts/self_improve.py run --iterations 100 \
 # Structural catalog: kwarg perturbations + add_heuristic / drop_heuristic ops
 uv run python scripts/self_improve.py run --iterations 100 \
     --structural --adaptive
+
+# End-of-loop hold-out validation against an independent base_seed,
+# fail with exit code 3 if the ladder is flagged as overfit
+uv run python scripts/self_improve.py run --iterations 100 \
+    --mode standard --holdout-base-seed 1234 --fail-on-overfit
 
 # Inspect the ledger
 uv run python scripts/self_improve.py summary

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,75 @@
 
 ## Recent Improvements (continued)
 
+### Hold-Out Validation Set for Self-Improvement Loop (2026-05-08)
+- [x] **New `panobbgo.self_improve.LoopHoldoutRecord`** — third record
+      type alongside `LoopIterationRecord` / `LoopGuardRecord`; closes
+      the §10 "Hold-out validation set" item in
+      `planning/SELF_IMPROVEMENT_LOOP.md`.  At the end of every loop
+      run, the seed and final-top of the accepted ladder are
+      re-measured on instances drawn from an *independent*
+      `base_seed` SHA-256 stream, and the shrinking-gap drift is
+      reported on the JSONL ledger as `record_type="holdout"`.
+  - **Why it matters.**  The anti-cherry-pick guard catches drift
+    *within* the training base_seed family — it varies only
+    `randomize_iteration` and keeps `HarnessConfig.seed` constant.  A
+    mutation that overfits to peculiarities of the training base_seed
+    family slips through silently because the guard's "fresh"
+    instances are still drawn from the same SHA-256 stream.  The
+    hold-out re-measures on a *completely* independent base_seed, so
+    an overfit ladder is exposed by ``drift < -eps_overfit``.
+- [x] **`LoopConfig` knobs** — `holdout_base_seed` (0 = disabled),
+      `holdout_iterations` (5 by default), `holdout_iteration_offset`
+      (0 by default), `holdout_eps_overfit` (0.05 by default).
+      `LoopConfig.__post_init__` rejects `holdout_base_seed ==
+      base_seed` (other than 0) — equal values would collapse the
+      check to a glorified guard with offset 0.
+- [x] **`LoopConfig.holdout_harness_config()`** — sibling to
+      `harness_config()` that swaps the `seed` field to
+      `holdout_base_seed`; every other knob (mode, reps, budget,
+      `strategies_override`) matches the training run.
+- [x] **`SelfImprover._run_holdout()`** + helpers
+      (`_holdout_enabled`, `_measure_holdout`, `_print_holdout`).
+      Skipped silently when (a) disabled, (b) the loop ran zero
+      iterations, or (c) `randomize=False` (the fixed battery is
+      unaffected by base_seed, so a hold-out check would be no
+      signal).
+- [x] **New public entry-point `SelfImprover.run_full()`** — returns
+      `(iter_records, guard_records, holdout_records)` for callers
+      that want all three signals.  `SelfImprover.run()` keeps its
+      original return type for backward compatibility;
+      `run_with_guard_records()` returns just the first two.
+- [x] **CLI flags** `--holdout-base-seed`, `--holdout-iterations`,
+      `--holdout-iteration-offset`, `--holdout-eps-overfit`,
+      `--fail-on-overfit` (exits `3` on a flagged ladder) on
+      `scripts/self_improve.py run`; `summary` distinguishes
+      hold-out records and prints drift / overfit verdict.
+- [x] **17 new tests in `tests/test_self_improve.py`** (total 97):
+      - **`TestLoopConfigHoldout`** — defaults, negative-iterations
+        validation, negative-eps validation, equal-base-seed
+        rejection, zero-zero edge case, `holdout_harness_config`
+        propagation.
+      - **`TestSelfImproverHoldout`** — disabled-by-default,
+        skipped when `randomize=False`, skipped on zero iterations,
+        seed-only ladder records zero drift, hold-out uses the
+        independent base_seed for measurement, overfit flag fires
+        when gap collapses, no flag when gap holds, ledger writes
+        `record_type='holdout'` line, `run()` keeps backward
+        compatibility.
+      - **`TestLoopHoldoutRecord`** — `to_dict` round-trip with JSON
+        serialisation.
+- [x] **Documentation updated**
+  - `planning/SELF_IMPROVEMENT_LOOP.md`: §2 missing-pieces list
+    refreshed; §10 hold-out item resolved; Phase 6 checklist updated;
+    new §12 dated entry; "Next iteration ideas" replaced with
+    multi-seed hold-out / auto-rollback follow-up tickets.
+  - `doc/source/guide_benchmarking.rst`: new "Hold-out validation
+    set" subsection with algorithm, CLI examples, programmatic
+    example, and the independence-from-the-guard note.
+  - `doc/source/guide.rst`: quick-nav entry mentions the hold-out.
+  - `AGENTS.md`: self-improvement loop subsection lists the
+    hold-out feature with run-the-loop bash example.
+
 ### PSO adaptive inertia (Shi-Eberhart 1998) (2026-05-07)
 - [x] **`panobbgo/heuristics/pso.py`** — :class:`PSO` gains an opt-in
       ``w_end`` keyword argument.  When set, a new

--- a/doc/source/guide.rst
+++ b/doc/source/guide.rst
@@ -41,7 +41,7 @@ Quick Navigation
    * - **Interested in research?**
      - Explore :doc:`guide_research` for related work, theoretical properties, and future directions
    * - **Want to measure progress?**
-     - Read :doc:`guide_benchmarking` for the composite score, external baselines, parametrically randomised problems, the statistical acceptance rule, the autonomous self-improvement loop driver, the anti-cherry-pick guard, the adaptive Thompson-sampling mutation sampler, the structural ``add_heuristic`` / ``drop_heuristic`` portfolio mutations, the dual-topology PSO (``gbest`` / ``lbest``) candidate pool, and the L-SHADE adaptive Differential Evolution heuristic (Tanabe-Fukunaga 2014)
+     - Read :doc:`guide_benchmarking` for the composite score, external baselines, parametrically randomised problems, the statistical acceptance rule, the autonomous self-improvement loop driver, the anti-cherry-pick guard, the hold-out validation set, the adaptive Thompson-sampling mutation sampler, the structural ``add_heuristic`` / ``drop_heuristic`` portfolio mutations, the dual-topology PSO (``gbest`` / ``lbest``) candidate pool, and the L-SHADE adaptive Differential Evolution heuristic (Tanabe-Fukunaga 2014)
 
 Guide Contents
 --------------

--- a/doc/source/guide_benchmarking.rst
+++ b/doc/source/guide_benchmarking.rst
@@ -727,6 +727,102 @@ Programmatic use:
 The ``--structural`` flag is **off by default** so existing CLI
 invocations and existing ledgers stay byte-identical.
 
+Hold-out validation set
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The anti-cherry-pick guard catches drift inside the *training*
+``base_seed`` family — it varies only ``randomize_iteration`` and keeps
+the ``HarnessConfig.seed`` constant.  A mutation that overfits to
+peculiarities of the training base-seed family slips through: the
+guard's "fresh" instances are still drawn from the same SHA-256 stream.
+
+The **hold-out validation set** closes that gap.  At the end of the
+loop run, when
+:attr:`~panobbgo.self_improve.LoopConfig.holdout_base_seed` is non-zero
+and :attr:`~panobbgo.self_improve.LoopConfig.holdout_iterations` is
+positive, the loop re-measures both the **seed** ladder entry and the
+**final top** entry on instances drawn from a completely independent
+``base_seed`` SHA-256 stream.  The two scores are averaged over
+``holdout_iterations`` distinct ``randomize_iteration`` values and
+compared to the training-time ``last_validated_score`` recorded on the
+ladder.  If the hold-out gap (``top − seed``) is smaller than the
+training gap by more than
+:attr:`~panobbgo.self_improve.LoopConfig.holdout_eps_overfit`, the
+:class:`~panobbgo.self_improve.LoopHoldoutRecord` is flagged
+``overfit=True``.
+
+Algorithm:
+
+1. After all loop iterations have completed (and the guard has done
+   its work), run :meth:`~panobbgo.self_improve.SelfImprover._run_holdout`.
+2. Build a :class:`~panobbgo.harness.HarnessConfig` whose ``seed`` is
+   the **independent** ``holdout_base_seed`` (every other knob — mode,
+   reps, budget, ``strategies_override`` — matches the training run).
+3. For ``k = 0 … holdout_iterations - 1``, set
+   ``randomize_iteration = holdout_iteration_offset + k`` and measure
+   both the seed and top spec lists.  Average to get
+   ``seed_holdout_score`` and ``top_holdout_score``.
+4. ``drift = (top_holdout − seed_holdout) − (top_training −
+   seed_training)``.  Negative drift means the gap shrank on hold-out
+   (overfit); within tolerance means the improvement generalises.
+5. Append a :class:`~panobbgo.self_improve.LoopHoldoutRecord` to the
+   ledger (``record_type = "holdout"``) so audits can replay the
+   third signal alongside iteration and guard records.
+
+Compute cost is fixed: ``2 × holdout_iterations`` harness runs at the
+end of the loop (or just ``holdout_iterations`` when the ladder has
+only the seed entry — no accepted mutations to validate).
+
+The hold-out is **disabled by default** (``holdout_base_seed = 0``)
+for backward compatibility.  Pick any independent base seed (e.g.
+``1234``) for unattended runs where overfitting to the training
+``base_seed`` is the dominant remaining risk.
+
+CLI:
+
+.. code-block:: bash
+
+   # Basic: 50 iterations on standard, hold-out at base_seed=1234
+   uv run python scripts/self_improve.py run --iterations 50 \
+       --mode standard --holdout-base-seed 1234
+
+   # Stricter: fail with exit code 3 if hold-out flags overfit
+   uv run python scripts/self_improve.py run --iterations 100 \
+       --mode standard --holdout-base-seed 1234 \
+       --holdout-eps-overfit 0.03 --fail-on-overfit
+
+Programmatic use:
+
+.. code-block:: python
+
+   from panobbgo.self_improve import LoopConfig, SelfImprover
+
+   cfg = LoopConfig(
+       iterations=50,
+       mode="standard",
+       guard_interval=10,
+       holdout_base_seed=1234,        # independent of base_seed=42
+       holdout_iterations=5,
+       holdout_eps_overfit=0.05,
+   )
+   iter_records, guard_records, holdout_records = (
+       SelfImprover(cfg).run_full()
+   )
+
+   if holdout_records:
+       ho = holdout_records[-1]
+       if ho.overfit:
+           print(f"WARNING: ladder overfits training base_seed (drift={ho.drift:+.4f})")
+       else:
+           print(f"Improvement generalises (drift={ho.drift:+.4f})")
+
+The hold-out is **independent** of the guard.  Both can be on
+simultaneously: the guard runs periodically inside the loop and
+catches drift between iterations within the training base_seed
+family; the hold-out runs once at the end and catches overfit to the
+training base_seed family itself.  Together they cover the two main
+overfitting modes the loop can suffer from.
+
 
 Extending the harness
 ---------------------

--- a/panobbgo/self_improve.py
+++ b/panobbgo/self_improve.py
@@ -87,6 +87,35 @@ stable entry is found or the seed strategies are reached.  Set
 ``10``) to enable; ``0`` (default) disables the guard so existing
 configurations behave identically.
 
+Hold-out validation set
+-----------------------
+
+The guard catches drift inside the *training* base-seed family — it uses
+the same :attr:`HarnessConfig.seed` and only varies
+:attr:`HarnessConfig.randomize_iteration`.  A mutation that overfits to
+peculiarities of the training base-seed family will *not* be caught: the
+guard's "fresh" instances are drawn from the same SHA-256 stream.
+
+The hold-out validation closes that gap.  At the **end** of the loop run
+(once :attr:`LoopConfig.iterations` are exhausted), if
+:attr:`LoopConfig.holdout_base_seed` is non-zero and
+:attr:`LoopConfig.holdout_iterations` is positive, the loop re-measures
+both the **seed** ladder entry and the **final top** entry on a
+completely independent ``base_seed`` family.  The two scores are
+averaged over ``holdout_iterations`` distinct instances and compared
+to the training-time scores recorded on the ladder.  If the
+"top minus seed" gap on the hold-out is smaller than the training gap
+by more than :attr:`LoopConfig.holdout_eps_overfit`, the loop emits an
+``overfit=True`` :class:`LoopHoldoutRecord` and exits non-zero from the
+CLI when ``--fail-on-overfit`` is set.  Otherwise the record is written
+informationally so an auditor can inspect the generalisation drift.
+
+Hold-out is one-shot at the end of the loop and uses fresh randomized
+instances, so its compute cost is fixed:
+``2 × holdout_iterations`` harness runs — typically a small fraction
+of the loop's total budget.  Disabled by default
+(``holdout_base_seed = 0``) so existing configurations behave identically.
+
 Safety rails (§8 in the plan)
 -----------------------------
 
@@ -1319,6 +1348,29 @@ class LoopConfig:
             seeds its bandit history from any existing
             :attr:`ledger_path` before the first iteration.  Useful when
             resuming a long unattended run.
+        holdout_base_seed: Independent ``base_seed`` used for the
+            end-of-loop hold-out validation.  ``0`` (default) disables
+            hold-out entirely.  Should differ from :attr:`base_seed` —
+            using the same value collapses the hold-out check to the
+            anti-cherry-pick guard with offset ``0`` and is rejected at
+            validation time.  See "Hold-out validation set" in the module
+            docstring for the full rationale.
+        holdout_iterations: Number of distinct ``randomize_iteration``
+            values to average over when computing the hold-out composite
+            for both the seed and the top ladder entries.  Must be
+            non-negative.  ``0`` (with ``holdout_base_seed != 0``) is a
+            valid no-op.
+        holdout_iteration_offset: Starting ``randomize_iteration`` index
+            for the hold-out sweep.  Almost always ``0`` is fine because
+            ``holdout_base_seed`` already gives an independent SHA-256
+            stream, but the knob exists for users who want to walk a
+            specific window of instances (e.g. for replication studies).
+        holdout_eps_overfit: Drift tolerance on the
+            ``(top − seed)`` gap.  When the hold-out gap is smaller than
+            the training-time gap by more than this amount, the
+            :class:`LoopHoldoutRecord` is flagged ``overfit=True``.
+            Default ``0.05`` matches the per-pair regression bound used
+            by the statistical-acceptance rule.
     """
 
     iterations: int = 5
@@ -1344,6 +1396,10 @@ class LoopConfig:
     adaptive_prior_alpha: float = 1.0
     adaptive_prior_beta: float = 1.0
     adaptive_prime_from_ledger: bool = False
+    holdout_base_seed: int = 0
+    holdout_iterations: int = 5
+    holdout_iteration_offset: int = 0
+    holdout_eps_overfit: float = 0.05
 
     def __post_init__(self) -> None:
         if self.iterations < 0:
@@ -1358,6 +1414,19 @@ class LoopConfig:
             raise ValueError(f"adaptive_prior_alpha must be > 0, got {self.adaptive_prior_alpha}")
         if self.adaptive_prior_beta <= 0:
             raise ValueError(f"adaptive_prior_beta must be > 0, got {self.adaptive_prior_beta}")
+        if self.holdout_iterations < 0:
+            raise ValueError(f"holdout_iterations must be >= 0, got {self.holdout_iterations}")
+        if self.holdout_eps_overfit < 0:
+            raise ValueError(f"holdout_eps_overfit must be >= 0, got {self.holdout_eps_overfit}")
+        # An independent base_seed is the entire point — silently treating
+        # equal values as "ok" would let the loop ship a hold-out that
+        # collapses to a glorified guard check, which is exactly the
+        # measurement gap this feature exists to close.
+        if self.holdout_base_seed != 0 and self.holdout_base_seed == self.base_seed:
+            raise ValueError(
+                f"holdout_base_seed must differ from base_seed (both={self.base_seed});"
+                " hold-out is meant to draw from a *different* SHA-256 stream"
+            )
 
     def harness_config(
         self,
@@ -1370,6 +1439,30 @@ class LoopConfig:
             budget=self.budget,
             reps=self.reps,
             seed=self.base_seed,
+            strategies=self.strategy_names,
+            timeout_per_run=self.timeout_per_run,
+            randomize=self.randomize,
+            randomize_iteration=iteration_id,
+            strategies_override=strategies_override,
+        )
+
+    def holdout_harness_config(
+        self,
+        strategies_override: List[StrategySpec],
+        iteration_id: int,
+    ) -> HarnessConfig:
+        """Build the :class:`HarnessConfig` used by hold-out validation.
+
+        Identical to :meth:`harness_config` except that ``seed`` is taken
+        from :attr:`holdout_base_seed`.  This swaps the SHA-256 instance
+        stream wholesale, giving the hold-out a genuinely independent set
+        of randomized problems.
+        """
+        return HarnessConfig(
+            mode=self.mode,
+            budget=self.budget,
+            reps=self.reps,
+            seed=self.holdout_base_seed,
             strategies=self.strategy_names,
             timeout_per_run=self.timeout_per_run,
             randomize=self.randomize,
@@ -1531,6 +1624,121 @@ class LoopGuardRecord:
         }
 
 
+@dataclass
+class LoopHoldoutRecord:
+    """One ledger line — outcome of the end-of-loop hold-out validation.
+
+    Run once at the end of :meth:`SelfImprover.run` when
+    :attr:`LoopConfig.holdout_base_seed` is non-zero and
+    :attr:`LoopConfig.holdout_iterations` is positive.  The hold-out
+    re-measures both the **seed** ladder entry and the **final top**
+    entry on instances drawn from a completely independent
+    ``base_seed`` SHA-256 stream, then compares the on-hold-out gap
+    ``top − seed`` to the on-training gap.  A drop of more than
+    :attr:`LoopConfig.holdout_eps_overfit` is flagged as overfitting.
+
+    Unlike the anti-cherry-pick guard, the hold-out:
+
+    * runs **once** at the end of the loop (cheap), and
+    * uses an **independent base_seed** rather than the training
+      base_seed with an iteration offset, so it catches overfit to the
+      base_seed family that the guard cannot see.
+
+    Attributes:
+        timestamp: ISO-8601 UTC timestamp.
+        duration_seconds: Wall-clock cost of all hold-out re-measurements.
+        holdout_base_seed: The independent ``base_seed`` used for the
+            hold-out.
+        holdout_iterations: Number of distinct ``randomize_iteration``
+            values averaged for both seed and top.
+        holdout_iteration_offset: Starting iteration_id for the sweep
+            (passed through from :attr:`LoopConfig`).
+        seed_holdout_score: Mean composite of the **seed** ladder entry
+            evaluated on the hold-out instances.
+        top_holdout_score: Mean composite of the **top** ladder entry
+            evaluated on the hold-out instances.  Equals
+            :attr:`seed_holdout_score` when the ladder has only the seed
+            (no accepted mutations).
+        seed_training_score: ``last_validated_score`` of the seed entry
+            recorded during the training loop.  ``NaN`` when the seed
+            never got a baseline measurement (e.g. a zero-iteration
+            run).
+        top_training_score: ``last_validated_score`` of the top ladder
+            entry at the moment the hold-out runs.  Equals
+            :attr:`seed_training_score` when the ladder has only the
+            seed.
+        holdout_delta: ``top_holdout_score − seed_holdout_score``.  This
+            is the *generalisation* effect size of all accepted
+            mutations on a held-out instance family.
+        training_delta: ``top_training_score − seed_training_score``.
+            This is the *training* effect size; the loop's claimed
+            improvement.
+        drift: ``holdout_delta − training_delta``.  Negative values
+            mean the gain shrank on hold-out (overfit); zero means it
+            generalised exactly; positive means the hold-out happened
+            to like the mutation even more than the training set
+            (within noise, treated as fine).
+        overfit: ``True`` iff ``drift < -eps_overfit``.
+        eps_overfit: Tolerance from :attr:`LoopConfig.holdout_eps_overfit`.
+        top_iteration: Iteration index of the final ladder top, ``-1``
+            for the seed.
+        ladder_size: Length of the ladder at the moment hold-out ran.
+        base_seed: The loop's *training* base_seed (for cross-reference
+            against the iteration ledger).
+        mode: Harness mode used for the hold-out (same as the loop).
+        reasons: Human-readable bullet points: skipped, overfit, or
+            generalised.
+        record_type: Always ``"holdout"``; lets ledger consumers
+            distinguish hold-out records from iteration and guard
+            records.
+    """
+
+    timestamp: str
+    duration_seconds: float
+    holdout_base_seed: int
+    holdout_iterations: int
+    holdout_iteration_offset: int
+    seed_holdout_score: float
+    top_holdout_score: float
+    seed_training_score: float
+    top_training_score: float
+    holdout_delta: float
+    training_delta: float
+    drift: float
+    overfit: bool
+    eps_overfit: float
+    top_iteration: int
+    ladder_size: int
+    base_seed: int = 42
+    mode: str = "quick"
+    reasons: List[str] = field(default_factory=list)
+    record_type: str = "holdout"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "record_type": self.record_type,
+            "timestamp": self.timestamp,
+            "duration_seconds": self.duration_seconds,
+            "holdout_base_seed": int(self.holdout_base_seed),
+            "holdout_iterations": int(self.holdout_iterations),
+            "holdout_iteration_offset": int(self.holdout_iteration_offset),
+            "seed_holdout_score": float(self.seed_holdout_score),
+            "top_holdout_score": float(self.top_holdout_score),
+            "seed_training_score": float(self.seed_training_score),
+            "top_training_score": float(self.top_training_score),
+            "holdout_delta": float(self.holdout_delta),
+            "training_delta": float(self.training_delta),
+            "drift": float(self.drift),
+            "overfit": bool(self.overfit),
+            "eps_overfit": float(self.eps_overfit),
+            "top_iteration": int(self.top_iteration),
+            "ladder_size": int(self.ladder_size),
+            "base_seed": int(self.base_seed),
+            "mode": self.mode,
+            "reasons": list(self.reasons),
+        }
+
+
 # ---------------------------------------------------------------------------
 # Driver
 # ---------------------------------------------------------------------------
@@ -1592,29 +1800,47 @@ class SelfImprover:
     def run(self, verbose: bool = False) -> List[LoopIterationRecord]:
         """Run the loop and return the per-iteration records.
 
-        Guard records (:class:`LoopGuardRecord`) are written to the
-        ledger alongside iteration records but are not returned here —
-        the contract of :meth:`run` is unchanged for backward
-        compatibility.  Use :meth:`run_with_guard_records` when both
-        are wanted in-process, or read the ledger to recover them.
+        Guard and hold-out records (:class:`LoopGuardRecord`,
+        :class:`LoopHoldoutRecord`) are written to the ledger alongside
+        iteration records but are not returned here — the contract of
+        :meth:`run` is unchanged for backward compatibility.  Use
+        :meth:`run_with_guard_records` for ``(iter, guard)`` or
+        :meth:`run_full` for ``(iter, guard, holdout)`` when those are
+        wanted in-process.  Reading the ledger recovers all three.
         """
-        records, _ = self._run_internal(verbose=verbose)
+        records, _, _ = self._run_internal(verbose=verbose)
         return records
 
     def run_with_guard_records(self, verbose: bool = False) -> Tuple[List[LoopIterationRecord], List[LoopGuardRecord]]:
         """Run the loop and return ``(iteration_records, guard_records)``.
 
-        The two lists are returned separately so existing callers of
-        :meth:`run` keep their type contract.  Both lists are also
-        persisted to the ledger.
+        Hold-out records, when produced, are persisted to the ledger
+        but not returned by this method.  Use :meth:`run_full` to also
+        receive the hold-out record in-process.
+        """
+        records, guards, _ = self._run_internal(verbose=verbose)
+        return records, guards
+
+    def run_full(
+        self, verbose: bool = False
+    ) -> Tuple[List[LoopIterationRecord], List[LoopGuardRecord], List["LoopHoldoutRecord"]]:
+        """Run the loop and return all three record streams.
+
+        Returns ``(iteration_records, guard_records, holdout_records)``.
+        The hold-out list is empty when hold-out is disabled
+        (``LoopConfig.holdout_base_seed == 0``) or when the loop ran
+        zero iterations.
         """
         return self._run_internal(verbose=verbose)
 
-    def _run_internal(self, verbose: bool = False) -> Tuple[List[LoopIterationRecord], List[LoopGuardRecord]]:
+    def _run_internal(
+        self, verbose: bool = False
+    ) -> Tuple[List[LoopIterationRecord], List[LoopGuardRecord], List["LoopHoldoutRecord"]]:
         current = self._load_seed_strategies()
         rng = np.random.default_rng(self.config.mutation_seed)
         records: List[LoopIterationRecord] = []
         guard_records: List[LoopGuardRecord] = []
+        holdout_records: List["LoopHoldoutRecord"] = []
         ladder: List[LadderEntry] = [
             LadderEntry(iteration=-1, specs=list(current), last_validated_score=float("nan"), proposal=None)
         ]
@@ -1724,7 +1950,19 @@ class SelfImprover:
                 if guard_record.rolled_back:
                     current = list(ladder[-1].specs)
 
-        return records, guard_records
+        # End-of-loop hold-out validation.  Skipped when disabled, when
+        # the loop never produced a baseline measurement, or when the
+        # battery is non-randomized (in which case a different base_seed
+        # would not change the instances and the check is meaningless).
+        if self._holdout_enabled() and len(records) > 0:
+            holdout_record = self._run_holdout(ladder, verbose)
+            if holdout_record is not None:
+                holdout_records.append(holdout_record)
+                ledger.write(holdout_record)
+                if verbose:
+                    self._print_holdout(holdout_record)
+
+        return records, guard_records, holdout_records
 
     # ------------------------------------------------------------------
     # Helpers
@@ -1918,6 +2156,143 @@ class SelfImprover:
             return False
         return guard_score < stored_score - self.config.guard_eps_ladder
 
+    # ------------------------------------------------------------------
+    # Hold-out validation
+    # ------------------------------------------------------------------
+
+    def _holdout_enabled(self) -> bool:
+        """Return True iff the hold-out validation is configured to run.
+
+        Three knobs gate this: an independent ``base_seed``, a positive
+        iteration count, and the randomized battery itself — without
+        randomization a different ``base_seed`` does not produce
+        different instances and the check would be vacuous.
+        """
+        return (
+            int(self.config.holdout_base_seed) != 0
+            and int(self.config.holdout_iterations) > 0
+            and bool(self.config.randomize)
+        )
+
+    def _measure_holdout(
+        self,
+        specs: List[StrategySpec],
+        iteration_id: int,
+        label: str,
+        verbose: bool,
+    ) -> HarnessResult:
+        """Single hold-out measurement on the independent base_seed."""
+        hc = self.config.holdout_harness_config(specs, iteration_id)
+        if verbose:
+            print(f"[self_improve] hold-out measuring {label} at iter_id={iteration_id}")
+        return self._harness_factory(hc).run(verbose=False)
+
+    def _run_holdout(
+        self,
+        ladder: List[LadderEntry],
+        verbose: bool,
+    ) -> Optional["LoopHoldoutRecord"]:
+        """Re-measure seed and top of the ladder on an independent base_seed.
+
+        Returns ``None`` only if the ladder is empty (defensive — by the
+        time this is called the ladder always has at least the seed
+        entry).  Otherwise produces a :class:`LoopHoldoutRecord` whose
+        ``overfit`` flag is set when the on-hold-out improvement gap
+        falls more than :attr:`LoopConfig.holdout_eps_overfit` short of
+        the on-training gap.
+        """
+        if not ladder:
+            return None
+
+        start = time.time()
+        seed_entry = ladder[0]
+        top_entry = ladder[-1]
+        seed_only = top_entry is seed_entry  # ladder never accepted anything
+
+        n_iters = int(self.config.holdout_iterations)
+        offset = int(self.config.holdout_iteration_offset)
+        seed_scores: List[float] = []
+        top_scores: List[float] = []
+
+        for k in range(n_iters):
+            iter_id = offset + k
+            seed_result = self._measure_holdout(seed_entry.specs, iter_id, "seed", verbose)
+            seed_scores.append(float(seed_result.composite_score))
+            if seed_only:
+                top_scores.append(seed_scores[-1])
+            else:
+                top_result = self._measure_holdout(top_entry.specs, iter_id, "top", verbose)
+                top_scores.append(float(top_result.composite_score))
+
+        seed_holdout = float(np.mean(seed_scores)) if seed_scores else 0.0
+        top_holdout = float(np.mean(top_scores)) if top_scores else seed_holdout
+
+        # ``last_validated_score`` is the most recent training-time
+        # measurement.  When the seed never recorded a baseline (e.g. a
+        # zero-iteration loop, which we filter out before calling this),
+        # NaN is mapped to 0.0 so the delta stays well-defined.
+        seed_training = float(seed_entry.last_validated_score) if not np.isnan(seed_entry.last_validated_score) else 0.0
+        top_training = (
+            float(top_entry.last_validated_score) if not np.isnan(top_entry.last_validated_score) else seed_training
+        )
+
+        holdout_delta = top_holdout - seed_holdout
+        training_delta = top_training - seed_training
+        drift = holdout_delta - training_delta
+        overfit = drift < -float(self.config.holdout_eps_overfit)
+
+        reasons: List[str] = []
+        if seed_only:
+            reasons.append(
+                "ladder has only the seed entry — no accepted mutations to validate; "
+                "hold-out scores recorded for reference but drift is 0 by construction"
+            )
+        elif overfit:
+            reasons.append(
+                f"hold-out drift {drift:+.4f} below -eps_overfit "
+                f"({-float(self.config.holdout_eps_overfit):.4f}); "
+                f"on-hold-out gap {holdout_delta:+.4f} vs on-training {training_delta:+.4f} "
+                "— the ladder appears to overfit the training base_seed family"
+            )
+        else:
+            reasons.append(
+                f"hold-out drift {drift:+.4f} within tolerance "
+                f"(>= {-float(self.config.holdout_eps_overfit):.4f}); "
+                f"on-hold-out gap {holdout_delta:+.4f} vs on-training {training_delta:+.4f} "
+                "— improvement appears to generalise"
+            )
+
+        return LoopHoldoutRecord(
+            timestamp=datetime.now(tz=timezone.utc).isoformat(),
+            duration_seconds=time.time() - start,
+            holdout_base_seed=int(self.config.holdout_base_seed),
+            holdout_iterations=n_iters,
+            holdout_iteration_offset=offset,
+            seed_holdout_score=seed_holdout,
+            top_holdout_score=top_holdout,
+            seed_training_score=seed_training,
+            top_training_score=top_training,
+            holdout_delta=float(holdout_delta),
+            training_delta=float(training_delta),
+            drift=float(drift),
+            overfit=bool(overfit),
+            eps_overfit=float(self.config.holdout_eps_overfit),
+            top_iteration=int(top_entry.iteration),
+            ladder_size=len(ladder),
+            base_seed=int(self.config.base_seed),
+            mode=self.config.mode,
+            reasons=reasons,
+        )
+
+    @staticmethod
+    def _print_holdout(rec: "LoopHoldoutRecord") -> None:
+        verdict = "OVERFIT" if rec.overfit else "OK"
+        print(
+            f"[hold-out] {verdict}  drift={rec.drift:+.4f}  "
+            f"holdout_gap={rec.holdout_delta:+.4f}  training_gap={rec.training_delta:+.4f}  "
+            f"top_iter={rec.top_iteration}"
+        )
+
     @staticmethod
     def _print_iteration(rec: LoopIterationRecord) -> None:
         if rec.proposal is None:
@@ -1941,8 +2316,9 @@ class SelfImprover:
 class _LedgerWriter:
     """Append-only JSONL ledger.  Creates parent directories on demand.
 
-    Writes both :class:`LoopIterationRecord` and :class:`LoopGuardRecord`
-    instances; the ``record_type`` field distinguishes them on read.
+    Writes :class:`LoopIterationRecord`, :class:`LoopGuardRecord`, and
+    :class:`LoopHoldoutRecord` instances; the ``record_type`` field
+    distinguishes them on read.
     """
 
     def __init__(self, path: str) -> None:
@@ -1996,6 +2372,7 @@ __all__ = [
     "LoopConfig",
     "LoopIterationRecord",
     "LoopGuardRecord",
+    "LoopHoldoutRecord",
     "LadderEntry",
     "SelfImprover",
     "load_ledger",

--- a/planning/SELF_IMPROVEMENT_LOOP.md
+++ b/planning/SELF_IMPROVEMENT_LOOP.md
@@ -72,6 +72,12 @@ What's missing for a true self-improvement loop:
       (`planning/self_improve_ledger.jsonl`).  Each entry stores its
       ``last_validated_score``, refreshed every time the guard
       re-measures it.
+- [x] Hold-out validation set — shipped 2026-05-08 as
+      `LoopHoldoutRecord` and the `LoopConfig.holdout_*` knobs.
+      End-of-loop re-measure on an *independent* `base_seed`
+      catches overfit to the training base_seed family that the
+      anti-cherry-pick guard cannot see.  CLI: `--holdout-base-seed`,
+      `--fail-on-overfit`.
 
 ## 3. Architecture of the loop
 
@@ -401,6 +407,15 @@ Each phase is independently deliverable and keeps the framework usable.
       The Thompson sampler collapses both ops onto one arm per
       ``op`` so cold-start variance stays bounded.  CLI:
       ``scripts/self_improve.py run --structural``.
+- [x] Hold-out validation set (§10) — shipped 2026-05-08 as
+      :class:`panobbgo.self_improve.LoopHoldoutRecord` plus the
+      ``LoopConfig.holdout_base_seed`` / ``holdout_iterations`` /
+      ``holdout_iteration_offset`` / ``holdout_eps_overfit`` knobs and
+      the ``--holdout-base-seed`` / ``--fail-on-overfit`` CLI flags.
+      End-of-loop re-measure of seed + top ladder entries on an
+      *independent* ``base_seed`` SHA-256 stream catches overfit to
+      the training base_seed family — the failure mode the guard
+      cannot see (the guard varies only ``randomize_iteration``).
 - [ ] Broaden further: analyzer add/drop, swapping a strategy class
       itself (e.g., ``StrategyRewarding`` → ``StrategyUCB``).
 - [x] Stratified dimension sampling (§10) for cross-iteration score
@@ -576,6 +591,83 @@ the rationale, and a measured-impact number when available.
   measurable progress, plus registration tests for
   :mod:`panobbgo.heuristics` and the structural and kwarg
   catalogs.
+
+### 2026-05-08 — Hold-out validation set for the self-improvement loop
+
+* **What** — `panobbgo/self_improve.py`:
+  :class:`LoopHoldoutRecord` (a third ledger record type next to
+  :class:`LoopIterationRecord` and :class:`LoopGuardRecord`) plus the
+  :attr:`LoopConfig.holdout_base_seed` /
+  :attr:`LoopConfig.holdout_iterations` /
+  :attr:`LoopConfig.holdout_iteration_offset` /
+  :attr:`LoopConfig.holdout_eps_overfit` knobs and a new
+  :meth:`LoopConfig.holdout_harness_config` helper.
+  :class:`SelfImprover` gains :meth:`_holdout_enabled`,
+  :meth:`_measure_holdout`, and :meth:`_run_holdout` plus a public
+  :meth:`run_full` entrypoint that returns
+  ``(iter_records, guard_records, holdout_records)`` for tests and
+  callers that want the full audit trail.  The CLI gains
+  ``--holdout-base-seed``, ``--holdout-iterations``,
+  ``--holdout-iteration-offset``, ``--holdout-eps-overfit``, and
+  ``--fail-on-overfit`` (exits ``3`` on a flagged ladder).  The
+  ``summary`` subcommand now reports hold-out outcomes alongside
+  iteration and guard summaries.
+* **Why** — closes the Phase 6 / §10 *Hold-out validation set*
+  ticket.  The anti-cherry-pick guard catches drift inside the
+  *training* base_seed family — it varies only
+  ``randomize_iteration`` and keeps ``HarnessConfig.seed`` constant.
+  A mutation that overfits to peculiarities of the training base_seed
+  family slips through silently because the guard's "fresh" instances
+  are still drawn from the same SHA-256 stream.  The hold-out
+  re-measures the seed and the final top of the ladder on a
+  completely independent ``base_seed``, so an overfit ladder is
+  exposed by a shrinking ``top − seed`` gap on hold-out.  A bias of
+  ``drift < -eps_overfit`` is flagged ``overfit=True`` and, when
+  combined with ``--fail-on-overfit``, exits the CLI non-zero so the
+  signal is usable as an unattended-loop tripwire.
+* **Independence vs the guard** — the guard validates within the
+  training instance stream (same ``base_seed``, different
+  ``randomize_iteration``); the hold-out validates *across* training
+  streams (different ``base_seed``, same ``randomize_iteration``
+  range).  Together they cover the two axes along which the loop can
+  silently overfit.
+* **Defaults** — ``holdout_base_seed = 0`` (disabled) keeps existing
+  CLI invocations byte-identical.  When set, the value must differ
+  from :attr:`LoopConfig.base_seed`; equal values would collapse the
+  hold-out to a glorified guard check on offset ``0`` and the
+  ``LoopConfig`` constructor rejects them at validation time.
+  ``holdout_iterations = 5``, ``holdout_iteration_offset = 0``,
+  ``holdout_eps_overfit = 0.05`` are the recommended starting points.
+* **Skip rules** — hold-out is skipped silently when (a) disabled,
+  (b) the loop ran zero iterations, or (c) ``randomize=False`` (the
+  fixed battery is unaffected by ``base_seed``, so a hold-out check
+  would be no signal at all).
+* **Cost** — fixed: ``2 × holdout_iterations`` harness runs at the
+  end of the loop (or just ``holdout_iterations`` when the ladder
+  has only the seed, since both endpoints are the same spec list).
+  Cheap relative to the ``2 × iterations`` cost of the main loop.
+* **Tests** — `tests/test_self_improve.py` (17 new tests, total 97):
+  config validation (negative iterations, negative eps, equal
+  base_seed rejection, zero-zero edge case, `holdout_harness_config`
+  vs `harness_config` propagation), end-to-end behaviour
+  (disabled-by-default, skipped when randomize=False, skipped on
+  zero iterations, seed-only ladder records zero drift, hold-out
+  uses the independent base_seed for measurement, overfit flag fires
+  when gap collapses, no flag when gap holds, ledger writes
+  ``record_type='holdout'`` line), back-compat (`SelfImprover.run`
+  still returns a list of `LoopIterationRecord`), and `to_dict`
+  round-trip with JSON serialisation.
+* **Documentation updated**
+  - `planning/SELF_IMPROVEMENT_LOOP.md`: §2 missing-pieces list
+    refreshed; §10 Open Questions item resolved; Phase 6 checklist
+    updated; this §12 entry; Next iteration ideas reduced.
+  - `doc/source/guide_benchmarking.rst`: new "Hold-out validation
+    set" subsection with algorithm, CLI examples, programmatic
+    example, and the independence-from-the-guard note.
+  - `doc/source/guide.rst`: quick-nav entry mentions the hold-out.
+  - `AGENTS.md`: self-improvement loop subsection lists the
+    hold-out feature with run-the-loop bash example.
+  - `TODO.md`: this entry.
 
 ### 2026-05-07 — PSO adaptive inertia (Shi-Eberhart 1998)
 
@@ -807,7 +899,6 @@ the rationale, and a measured-impact number when available.
   Thompson sampler bucketing structural history into one arm, and an
   end-to-end loop run that accepts a structural drop on a fake
   harness.
-
 ### 2026-05-02 — Stratified dimension sampling for multi-dim families
 
 * **What** — `panobbgo/harness_randomized.py`:
@@ -999,13 +1090,6 @@ the §12 entry.  Natural next refinements:
   every accepted swap to keep the strategy's hyperparameters either
   compatible or to drop them on the floor; needs a translation table.
 
-#### Hold-out validation set
-
-Maintain a small fixed validation set of randomized instances drawn
-from a separate `base_seed`.  Use it (read-only) to spot-check the
-ladder once at the end of a loop run.  Cheaper than the periodic
-guard but complements it.
-
 #### PSO follow-ups (after 2026-05-05 ship)
 
 PSO landed 2026-05-05; the ``lbest`` ring topology shipped 2026-05-07
@@ -1076,3 +1160,37 @@ that is currently missing — Nelder-Mead is the only generic
 derivative-free local optimizer in the catalog, and it is
 known to underperform on ill-conditioned problems where BOBYQA's
 quadratic model directly captures curvature.
+
+#### Multi-seed hold-out for robust drift estimation
+
+The single-base-seed hold-out shipped 2026-05-08 catches overfit to
+the *training* base_seed family but reduces the entire generalisation
+question to one independent draw.  A natural upgrade is to evaluate
+the ladder on *several* independent ``holdout_base_seed`` values
+(e.g. ``[1234, 5678, 9012]``) and report the *worst* drift across
+them.  Needs:
+
+- A list-typed ``holdout_base_seeds`` knob (``int | List[int]``)
+  alongside the current scalar.
+- A reduction over the per-seed records (``min`` of drift, ``any``
+  of overfit) into a single CLI summary line.
+- Bootstrap CI on the drift estimate would be the next step beyond
+  that — turning the hold-out into a statistical test rather than
+  a point check.
+
+Cost scales linearly with the number of seeds; for a typical 5-seed
+hold-out at ``holdout_iterations=5`` that is ``2 × 5 × 5 = 50``
+extra harness runs at the end of the loop, still small compared to
+a typical ``2 × 100`` iteration loop.
+
+#### Auto-rollback on hold-out overfit
+
+When the hold-out flags ``overfit=True``, the loop currently just
+records and (optionally) exits.  A more aggressive remediation is
+to automatically pop the ladder back to the seed entry and persist
+the rollback in a new ``LoopHoldoutRollbackRecord`` so a subsequent
+``--adaptive-prime-from-ledger`` resume picks up the failure as a
+negative reward signal for *all* the rules that contributed to the
+discarded ladder.  Needs care around the bandit semantics: penalising
+all rules along the discarded path is more aggressive than penalising
+only the last one, and the right policy is an open question.

--- a/scripts/self_improve.py
+++ b/scripts/self_improve.py
@@ -59,6 +59,17 @@ Two subcommands:
         uv run python scripts/self_improve.py run --iterations 50 \\
             --structural --adaptive
 
+``--holdout-base-seed``
+    Enable end-of-loop hold-out validation against an independent
+    ``base_seed`` family.  After the main loop finishes, the seed and
+    final-top of the ladder are re-measured on instances drawn from
+    the hold-out base seed; an overfit ladder (gap shrinks more than
+    ``--holdout-eps-overfit`` on hold-out) is logged and, when
+    ``--fail-on-overfit`` is set, exits the CLI with code ``3``::
+
+        uv run python scripts/self_improve.py run --iterations 50 \\
+            --holdout-base-seed 1234 --fail-on-overfit
+
 Stop the loop early by ``touch STOP_SELF_IMPROVE`` (configurable via
 ``--stop-sentinel``); the current iteration will finish, then the loop
 exits and the ledger is preserved.
@@ -67,6 +78,7 @@ Exit codes
 ----------
 - ``0`` — loop completed (or stopped via sentinel).
 - ``1`` — argument error.
+- ``3`` — ``--fail-on-overfit`` and the hold-out flagged overfit.
 """
 
 from __future__ import annotations
@@ -246,6 +258,44 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     run_p.set_defaults(structural=False)
+    run_p.add_argument(
+        "--holdout-base-seed",
+        dest="holdout_base_seed",
+        type=int,
+        default=0,
+        help=(
+            "Independent base_seed for end-of-loop hold-out validation."
+            " Default 0 disables hold-out.  Must differ from --base-seed."
+        ),
+    )
+    run_p.add_argument(
+        "--holdout-iterations",
+        dest="holdout_iterations",
+        type=int,
+        default=5,
+        help="Number of distinct iteration_ids to average for the hold-out (default: 5)",
+    )
+    run_p.add_argument(
+        "--holdout-iteration-offset",
+        dest="holdout_iteration_offset",
+        type=int,
+        default=0,
+        help="Starting iteration_id for the hold-out sweep (default: 0)",
+    )
+    run_p.add_argument(
+        "--holdout-eps-overfit",
+        dest="holdout_eps_overfit",
+        type=float,
+        default=0.05,
+        help="Drift tolerance on top-vs-seed gap; below -eps flags overfit (default: 0.05)",
+    )
+    run_p.add_argument(
+        "--fail-on-overfit",
+        dest="fail_on_overfit",
+        action="store_true",
+        help="Exit with code 3 if the hold-out flags an overfit ladder",
+    )
+    run_p.set_defaults(fail_on_overfit=False)
     run_p.add_argument("--quiet", "-q", action="store_true", help="Suppress per-iteration output")
     run_p.set_defaults(func=_cmd_run)
 
@@ -289,9 +339,13 @@ def _cmd_run(args: argparse.Namespace) -> int:
         adaptive_prior_alpha=args.adaptive_prior_alpha,
         adaptive_prior_beta=args.adaptive_prior_beta,
         adaptive_prime_from_ledger=args.adaptive_prime_from_ledger,
+        holdout_base_seed=args.holdout_base_seed,
+        holdout_iterations=args.holdout_iterations,
+        holdout_iteration_offset=args.holdout_iteration_offset,
+        holdout_eps_overfit=args.holdout_eps_overfit,
     )
     improver = SelfImprover(cfg, catalog=catalog)
-    records = improver.run(verbose=not args.quiet)
+    records, _, holdout_records = improver.run_full(verbose=not args.quiet)
 
     n_accepts = sum(1 for r in records if r.accepted)
     n_skips = sum(1 for r in records if r.proposal is None)
@@ -305,6 +359,16 @@ def _cmd_run(args: argparse.Namespace) -> int:
             for s in snap:
                 cls, param, kind = s.rule_key
                 print(f"  {cls}.{param}[{kind}] -> {s.n_accepts}/{s.n_attempts} ({s.accept_rate:.0%})")
+    if holdout_records:
+        ho = holdout_records[-1]
+        verdict = "OVERFIT" if ho.overfit else "OK"
+        print(
+            f"[self_improve] hold-out: {verdict}  drift={ho.drift:+.4f}  "
+            f"holdout_gap={ho.holdout_delta:+.4f}  training_gap={ho.training_delta:+.4f}  "
+            f"(base_seed={ho.holdout_base_seed}, n={ho.holdout_iterations})"
+        )
+        if ho.overfit and args.fail_on_overfit:
+            return 3
     return 0
 
 
@@ -323,6 +387,7 @@ def _cmd_summary(args: argparse.Namespace) -> int:
 
     iter_records = [r for r in records if r.get("record_type", "iteration") == "iteration"]
     guard_records = [r for r in records if r.get("record_type") == "guard"]
+    holdout_records = [r for r in records if r.get("record_type") == "holdout"]
     n = len(iter_records)
     accepted = [r for r in iter_records if r.get("accepted")]
     skipped = [r for r in iter_records if r.get("proposal") is None]
@@ -330,6 +395,7 @@ def _cmd_summary(args: argparse.Namespace) -> int:
     accept_rate = (len(accepted) / len(decided)) if decided else 0.0
     best_delta = max((r.get("delta", 0.0) for r in decided), default=0.0)
     rolled_back = [r for r in guard_records if r.get("rolled_back")]
+    overfits = [r for r in holdout_records if r.get("overfit")]
 
     print(f"Ledger:        {path}")
     print(f"Iterations:    {n}  (decided={len(decided)}, skipped={len(skipped)})")
@@ -337,6 +403,8 @@ def _cmd_summary(args: argparse.Namespace) -> int:
     if guard_records:
         total_pops = sum(int(r.get("pops", 0)) for r in guard_records)
         print(f"Guards:        {len(guard_records)}  (rollbacks={len(rolled_back)}, total pops={total_pops})")
+    if holdout_records:
+        print(f"Hold-outs:     {len(holdout_records)}  (overfit={len(overfits)})")
     if decided:
         print(f"Best Δ seen:   {best_delta:+.4f}")
 
@@ -359,6 +427,17 @@ def _cmd_summary(args: argparse.Namespace) -> int:
                 f"score={r.get('guard_score'):.4f} vs stored "
                 f"{r.get('pre_guard_top_score'):.4f}; "
                 f"new top iter={r.get('rolled_back_to_iteration')}"
+            )
+    if holdout_records:
+        print("Hold-out validation:")
+        for r in holdout_records:
+            verdict = "OVERFIT" if r.get("overfit") else "OK"
+            print(
+                f"  {verdict}  drift={r.get('drift'):+.4f}  "
+                f"holdout_gap={r.get('holdout_delta'):+.4f} "
+                f"training_gap={r.get('training_delta'):+.4f}  "
+                f"top_iter={r.get('top_iteration')}  "
+                f"(base_seed={r.get('holdout_base_seed')}, n={r.get('holdout_iterations')})"
             )
     return 0
 

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -57,6 +57,7 @@ from panobbgo.self_improve import (
     LadderEntry,
     LoopConfig,
     LoopGuardRecord,
+    LoopHoldoutRecord,
     LoopIterationRecord,
     MutationCatalog,
     MutationProposal,
@@ -554,6 +555,7 @@ class _FakeHarness:
             {
                 "score": score,
                 "randomize_iteration": self.config.randomize_iteration,
+                "seed": self.config.seed,
                 "n_strategies": (
                     len(self.config.strategies_override) if self.config.strategies_override is not None else 0
                 ),
@@ -1915,3 +1917,366 @@ class TestStructuralEndToEnd:
         assert len(records) == 2
         assert all(r.proposal is None for r in records)
         assert all(r.reason_skipped is not None for r in records)
+
+
+# ===========================================================================
+# Hold-out validation set
+# ===========================================================================
+
+
+def _accept_radius_catalog() -> MutationCatalog:
+    """Catalog whose only rule perturbs ``_DummyHeuristicA.radius``.
+
+    Used by hold-out tests so the loop reliably proposes mutations
+    against ``_make_specs()`` and the bandit's accept rate is governed
+    purely by the ``score_fn`` we hand the fake harness.
+    """
+    return MutationCatalog(
+        [
+            MutationRule(
+                strategy_pattern="",
+                class_name="_DummyHeuristicA",
+                param_name="radius",
+                kind="log_uniform_perturb",
+                bounds=(0.005, 0.5),
+            ),
+        ]
+    )
+
+
+class TestLoopConfigHoldout:
+    """Validation of the hold-out config knobs."""
+
+    def test_defaults_disabled(self):
+        cfg = LoopConfig()
+        assert cfg.holdout_base_seed == 0
+        assert cfg.holdout_iterations == 5
+        assert cfg.holdout_iteration_offset == 0
+        assert cfg.holdout_eps_overfit == 0.05
+
+    def test_negative_iterations_raises(self):
+        with pytest.raises(ValueError, match="holdout_iterations"):
+            LoopConfig(holdout_iterations=-1)
+
+    def test_negative_eps_overfit_raises(self):
+        with pytest.raises(ValueError, match="holdout_eps_overfit"):
+            LoopConfig(holdout_eps_overfit=-0.1)
+
+    def test_holdout_base_seed_equal_to_base_seed_raises(self):
+        # The whole point is an *independent* SHA-256 stream.  Equal
+        # values would silently collapse the check; reject loudly.
+        with pytest.raises(ValueError, match="holdout_base_seed must differ"):
+            LoopConfig(base_seed=42, holdout_base_seed=42)
+
+    def test_holdout_base_seed_zero_does_not_collide_with_base_seed(self):
+        # 0 means "disabled" — the equality check must skip 0 even when
+        # base_seed is also 0.
+        cfg = LoopConfig(base_seed=0, holdout_base_seed=0)
+        assert cfg.holdout_base_seed == 0
+
+    def test_holdout_harness_config_uses_holdout_seed(self):
+        cfg = LoopConfig(base_seed=42, holdout_base_seed=99)
+        hc = cfg.holdout_harness_config([], iteration_id=7)
+        assert hc.seed == 99
+        assert hc.randomize_iteration == 7
+
+    def test_regular_harness_config_still_uses_base_seed(self):
+        cfg = LoopConfig(base_seed=42, holdout_base_seed=99)
+        hc = cfg.harness_config([], iteration_id=3)
+        assert hc.seed == 42  # unchanged
+        assert hc.randomize_iteration == 3
+
+
+class TestSelfImproverHoldout:
+    """End-to-end behaviour of the hold-out validation pass."""
+
+    def test_disabled_by_default(self, tmp_path):
+        """holdout_base_seed=0 must produce no hold-out records."""
+        cfg = LoopConfig(
+            iterations=2,
+            n_boot=100,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=True,
+            # holdout_base_seed defaults to 0 (disabled).
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.4)
+        _, _, holdout_records = si.run_full()
+        assert holdout_records == []
+
+    def test_skipped_when_randomize_false(self, tmp_path):
+        """randomize=False makes hold-out vacuous; the loop must skip it.
+
+        Without randomization, ``base_seed`` does not affect the
+        instances drawn — every measurement returns identical scores
+        and a hold-out check would be no signal at all.  The helper
+        ``_holdout_enabled`` guards against this so we never write a
+        meaningless ``LoopHoldoutRecord``.
+        """
+        cfg = LoopConfig(
+            iterations=2,
+            n_boot=100,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=False,
+            base_seed=42,
+            holdout_base_seed=99,
+            holdout_iterations=3,
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.4)
+        _, _, holdout_records = si.run_full()
+        assert holdout_records == []
+
+    def test_skipped_when_zero_iterations_run(self, tmp_path):
+        """Zero iterations means no ladder activity; hold-out is moot."""
+        cfg = LoopConfig(
+            iterations=0,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=True,
+            base_seed=42,
+            holdout_base_seed=99,
+            holdout_iterations=3,
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.4)
+        _, _, holdout_records = si.run_full()
+        assert holdout_records == []
+
+    def test_seed_only_ladder_records_zero_drift(self, tmp_path):
+        """When no mutation is accepted, holdout_delta == 0 by construction.
+
+        With ``score_fn`` constant the iteration produces zero delta and
+        the rule is rejected.  The ladder still has only the seed —
+        hold-out reports it as a no-op (drift 0) and overfit=False.
+        """
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=True,
+            base_seed=42,
+            holdout_base_seed=99,
+            holdout_iterations=3,
+            holdout_iteration_offset=0,
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        # Constant score: the iteration delta is 0 and the rule is rejected.
+        si._harness_factory = _make_factory(lambda c: 0.4)
+        iter_records, _, holdout_records = si.run_full()
+        assert iter_records[0].accepted is False
+        assert len(holdout_records) == 1
+        rec = holdout_records[0]
+        assert rec.top_iteration == -1  # ladder stayed at the seed
+        assert rec.ladder_size == 1
+        assert rec.holdout_delta == pytest.approx(0.0)
+        assert rec.training_delta == pytest.approx(0.0)
+        assert rec.drift == pytest.approx(0.0)
+        assert rec.overfit is False
+        assert any("only the seed entry" in r for r in rec.reasons)
+
+    def test_uses_holdout_base_seed_for_measurement(self, tmp_path):
+        """Hold-out calls must use ``holdout_base_seed``, not the training seed.
+
+        Sanity-checks that the SHA-256 instance stream is genuinely
+        independent: no hold-out call should go through with the
+        training base_seed.
+        """
+        call_log: List[Dict[str, Any]] = []
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=True,
+            base_seed=42,
+            holdout_base_seed=4242,
+            holdout_iterations=2,
+            holdout_iteration_offset=10,
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.5, call_log=call_log)
+        si.run_full()
+
+        training_calls = [c for c in call_log if c["seed"] == 42]
+        holdout_calls = [c for c in call_log if c["seed"] == 4242]
+        # 1 iter × 2 measurements (baseline + candidate) = 2 training calls.
+        assert len(training_calls) == 2
+        # 2 hold-out iterations × 2 ladder slots (seed + top) = 4.
+        # Note: when ladder has only seed, top_specs IS seed_specs so the
+        # branch only does one measurement per iter — handle both cases.
+        assert len(holdout_calls) in (2, 4)
+        # All hold-out iter ids must come from offset=10 sweep [10, 11].
+        assert {c["randomize_iteration"] for c in holdout_calls} == {10, 11}
+
+    def test_overfit_flagged_when_gap_collapses(self, tmp_path):
+        """A mutation that wins on training but collapses on hold-out is flagged.
+
+        Setup: training measurements have a +0.5 gap (seed=0.3,
+        top=0.8), so the iteration accepts decisively.  Hold-out
+        measurements (those using ``seed=99``) collapse: seed=0.3,
+        top=0.3 — zero gap.  Drift = 0 - 0.5 = -0.5 < -0.05, so the
+        record reports ``overfit=True``.
+        """
+        # Training calls alternate baseline (0.3) / candidate (0.8).
+        # Hold-out calls all return 0.3 — total collapse on the
+        # independent base_seed family.
+        counter = {"n": 0}
+
+        def score_fn(config: HarnessConfig) -> float:
+            if config.seed == 99:
+                # Hold-out — collapse.
+                return 0.3
+            n = counter["n"]
+            counter["n"] += 1
+            return 0.3 if n % 2 == 0 else 0.8
+
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=True,
+            base_seed=42,
+            holdout_base_seed=99,
+            holdout_iterations=3,
+            holdout_eps_overfit=0.05,
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(score_fn)
+        iter_records, _, holdout_records = si.run_full()
+        assert iter_records[0].accepted is True
+        assert len(holdout_records) == 1
+        rec = holdout_records[0]
+        assert rec.top_iteration == 0  # the mutation we just accepted
+        assert rec.ladder_size == 2
+        assert rec.training_delta == pytest.approx(0.5, abs=1e-6)
+        assert rec.holdout_delta == pytest.approx(0.0, abs=1e-6)
+        assert rec.drift == pytest.approx(-0.5, abs=1e-6)
+        assert rec.overfit is True
+        assert any("overfit" in r for r in rec.reasons)
+
+    def test_generalises_when_gap_holds(self, tmp_path):
+        """Improvement that holds on hold-out is *not* flagged as overfit."""
+        counter = {"n": 0}
+
+        def score_fn(config: HarnessConfig) -> float:
+            if config.seed == 99:
+                # Hold-out preserves the gap — slightly noisy but well within
+                # the eps_overfit tolerance.
+                ho = counter.get("ho", 0)
+                counter["ho"] = ho + 1
+                # Alternate seed-eval and top-eval; seed=0.3, top=0.78.
+                return 0.3 if ho % 2 == 0 else 0.78
+            n = counter["n"]
+            counter["n"] += 1
+            return 0.3 if n % 2 == 0 else 0.8
+
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=True,
+            base_seed=42,
+            holdout_base_seed=99,
+            holdout_iterations=4,  # even so seed/top alternation balances
+            holdout_eps_overfit=0.05,
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(score_fn)
+        iter_records, _, holdout_records = si.run_full()
+        assert iter_records[0].accepted is True
+        rec = holdout_records[0]
+        assert rec.overfit is False
+        # Drift |delta| stays within tolerance.
+        assert abs(rec.drift) < cfg.holdout_eps_overfit
+        assert any("generalise" in r for r in rec.reasons)
+
+    def test_writes_holdout_record_to_ledger(self, tmp_path):
+        """The hold-out record is appended to the JSONL ledger as
+        ``record_type='holdout'``.
+
+        Auditors loading the ledger must be able to filter to just the
+        hold-out records, so the type tag is the contract.
+        """
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=True,
+            base_seed=42,
+            holdout_base_seed=99,
+            holdout_iterations=2,
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.4)
+        si.run_full()
+
+        records = load_ledger(cfg.ledger_path)
+        types = [r.get("record_type") for r in records]
+        # Order: 1 iter, then 1 holdout record at the end.
+        assert types[-1] == "holdout"
+        assert types.count("holdout") == 1
+
+    def test_run_keeps_back_compatibility(self, tmp_path):
+        """:meth:`SelfImprover.run` still returns just iteration records."""
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=True,
+            base_seed=42,
+            holdout_base_seed=99,
+            holdout_iterations=2,
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.4)
+        records = si.run()
+        # Type stable: list of LoopIterationRecord, not a tuple.
+        assert isinstance(records, list)
+        assert all(isinstance(r, LoopIterationRecord) for r in records)
+
+
+class TestLoopHoldoutRecord:
+    """Round-trip and surface checks for the new dataclass."""
+
+    def test_to_dict_round_trip(self):
+        rec = LoopHoldoutRecord(
+            timestamp="2026-05-08T00:00:00+00:00",
+            duration_seconds=1.5,
+            holdout_base_seed=99,
+            holdout_iterations=4,
+            holdout_iteration_offset=0,
+            seed_holdout_score=0.30,
+            top_holdout_score=0.32,
+            seed_training_score=0.30,
+            top_training_score=0.80,
+            holdout_delta=0.02,
+            training_delta=0.50,
+            drift=-0.48,
+            overfit=True,
+            eps_overfit=0.05,
+            top_iteration=4,
+            ladder_size=3,
+            base_seed=42,
+            mode="quick",
+            reasons=["hold-out drift -0.4800 below -eps_overfit"],
+        )
+        d = rec.to_dict()
+        assert d["record_type"] == "holdout"
+        assert d["overfit"] is True
+        assert d["drift"] == pytest.approx(-0.48)
+        assert d["holdout_iterations"] == 4
+        assert d["base_seed"] == 42
+        assert d["mode"] == "quick"
+        # Round-trip through JSON to validate JSON-default coverage.
+        s = json.dumps(d)
+        parsed = json.loads(s)
+        assert parsed["record_type"] == "holdout"
+        assert parsed["holdout_base_seed"] == 99


### PR DESCRIPTION
## Summary

Closes the §10 *Hold-out validation set* item in
`planning/SELF_IMPROVEMENT_LOOP.md`. At the end of every loop run, the
seed and final top of the accepted ladder are re-measured on instances
drawn from a **completely independent** `base_seed` SHA-256 stream. A
shrinking `top − seed` gap (`drift < -eps_overfit`) flags overfit to the
training `base_seed` family — the failure mode the anti-cherry-pick
guard cannot see (the guard varies only `randomize_iteration` while
keeping `HarnessConfig.seed` constant).

This complements the guard along the orthogonal axis: the guard
validates *within* the training instance stream; the hold-out validates
*across* training streams. Together they cover the two main overfitting
modes the loop can suffer from.

## What changed

* **`panobbgo/self_improve.py`**
  - New `LoopHoldoutRecord` dataclass (`record_type='holdout'` for the
    JSONL ledger).
  - New `LoopConfig.holdout_base_seed` / `holdout_iterations` /
    `holdout_iteration_offset` / `holdout_eps_overfit` knobs.
  - New `LoopConfig.holdout_harness_config()` helper (sibling to
    `harness_config`, swaps the `seed` field to `holdout_base_seed`).
  - New `SelfImprover._holdout_enabled` / `_measure_holdout` /
    `_run_holdout` helpers; new public `run_full()` that returns
    `(iter, guard, holdout)` for callers wanting all three signals.
  - `__post_init__` rejects `holdout_base_seed == base_seed` (would
    silently collapse the check to a glorified guard with offset 0).
* **`scripts/self_improve.py`** — `--holdout-base-seed`,
  `--holdout-iterations`, `--holdout-iteration-offset`,
  `--holdout-eps-overfit`, `--fail-on-overfit` (exits `3` on a flagged
  ladder). `summary` now reports hold-out outcomes alongside iteration
  and guard summaries.
* **`tests/test_self_improve.py`** — 17 new tests (total 97) covering
  config validation, end-to-end behaviour, ledger persistence,
  backward compatibility, and `to_dict` round-trip with JSON.
* **Docs** — `planning/SELF_IMPROVEMENT_LOOP.md` (§2 / §10 / §12 /
  "Next iteration ideas"), `doc/source/guide_benchmarking.rst` (new
  *Hold-out validation set* subsection), `doc/source/guide.rst`
  quick-nav entry, `AGENTS.md` self-improvement loop subsection,
  `TODO.md`.

## Skip rules

The hold-out is silently skipped when:
- `holdout_base_seed = 0` (default, disabled), **or**
- the loop ran zero iterations, **or**
- `randomize = False` (the fixed battery is unaffected by `base_seed`,
  so a hold-out check would be no signal at all).

## Cost

Fixed: `2 × holdout_iterations` harness runs at the end of the loop (or
just `holdout_iterations` when the ladder has only the seed entry).
Cheap relative to a typical `2 × iterations` loop. Default
`holdout_base_seed = 0` keeps existing CLI invocations byte-identical.

## Test plan

- [x] `uv run pytest tests/` — 834 passed, 1 skipped, 0 failed
- [x] `uv run pyright panobbgo` — 0 errors
- [x] `uv run ruff format --check .` — 170 files clean
- [x] `uv run flake8 panobbgo --select=E9,F63,F7,F82` — 0 errors
- [x] End-to-end smoke test: `scripts/self_improve.py run --iterations 1
      --holdout-base-seed 1234 --holdout-iterations 2` produces a
      well-formed `record_type='holdout'` line in the JSONL ledger and
      the `summary` subcommand displays it correctly.

https://claude.ai/code/session_01LPf51XScBbRnKV9nde7nwG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPf51XScBbRnKV9nde7nwG)_