### PR TITLE
fix(logging): auto-quiet progress + color when stdout is not a TTY

### DIFF
--- a/.github/workflows/self_improve_nightly.yml
+++ b/.github/workflows/self_improve_nightly.yml
@@ -40,8 +40,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Need full history so we can push back to master.
-          fetch-depth: 0
+          # Shallow clone is enough to push fast-forward commits to
+          # master.  fetch-depth: 0 listed every remote branch in the
+          # log (~100 lines of noise on this repo).
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python ${{ env.PYTHON }}

--- a/panobbgo/logging/logger.py
+++ b/panobbgo/logging/logger.py
@@ -115,13 +115,17 @@ class PanobbgoLogger:
 
     def _load_config(self):
         """Load logging configuration."""
-        # Default configuration
+        # Default configuration.  Progress and status defaults follow
+        # stdout TTY detection so CI / piped logs stay quiet without
+        # having to wire a config knob.  Pass an explicit value in the
+        # config dict to override.
+        _is_tty = sys.stdout.isatty()
         defaults = {
             "default_level": "WARNING",
             "enabled_components": [],
-            "progress_enabled": True,
+            "progress_enabled": _is_tty,
             "progress_symbols": True,
-            "status_line_enabled": True,
+            "status_line_enabled": _is_tty,
             "status_update_frequency": 5,
             "always_show_errors": True,
             "always_show_warnings": True,

--- a/panobbgo/logging/progress.py
+++ b/panobbgo/logging/progress.py
@@ -44,9 +44,16 @@ class ProgressReporter:
     """
 
     def __init__(self):
-        self.enabled = True
+        # Auto-disable progress output when stdout is not a TTY (CI, pipes,
+        # redirected logs).  The per-evaluation progress chars + status
+        # line are designed for live human viewing; in a log file they
+        # are pure noise.  Callers that *want* progress in a log can set
+        # `.enabled = True` after construction or call
+        # `PanobbgoLogger.enable_progress_reporting()`.
+        _is_tty = sys.stdout.isatty()
+        self.enabled = _is_tty
         self.use_symbols = True
-        self.status_enabled = True
+        self.status_enabled = _is_tty
         self.update_frequency = 5  # Update status every N evaluations
 
         self.evaluation_count = 0

--- a/panobbgo/utils.py
+++ b/panobbgo/utils.py
@@ -21,6 +21,7 @@ Some utility functions, will move eventually.
 """
 
 import logging
+import sys
 import numpy as np
 
 
@@ -40,9 +41,18 @@ class ColoredFormatter(logging.Formatter):
         "ERROR": RED,
     }
 
-    def __init__(self):
-        msg = "%(runtime)f %(where)-15s $BOLD%(name)-5s$RESET %(levelname)-9s %(message)s"
-        msg = msg.replace("$RESET", ColoredFormatter.RESET_SEQ).replace("$BOLD", ColoredFormatter.BOLD_SEQ)
+    def __init__(self, use_color=None):
+        # use_color=None → auto-detect from stderr (the default
+        # StreamHandler target).  In a log file the ANSI escapes
+        # render as literal "^[[1m..." garbage, so non-TTY = plain.
+        if use_color is None:
+            use_color = sys.stderr.isatty()
+        self.use_color = use_color
+        if use_color:
+            msg = "%(runtime)f %(where)-15s $BOLD%(name)-5s$RESET %(levelname)-9s %(message)s"
+            msg = msg.replace("$RESET", ColoredFormatter.RESET_SEQ).replace("$BOLD", ColoredFormatter.BOLD_SEQ)
+        else:
+            msg = "%(runtime)f %(where)-15s %(name)-5s %(levelname)-9s %(message)s"
         logging.Formatter.__init__(self, fmt=msg)
 
     @staticmethod
@@ -56,13 +66,13 @@ class ColoredFormatter(logging.Formatter):
         import copy
 
         record = copy.copy(record)
-        levelname = record.levelname
-        if levelname in ColoredFormatter.COLORS:
-            col = ColoredFormatter.COLORS[levelname]
-            record.name = self.colorize(record.name, col, True)
-            # record.lineno = self.colorize(record.lineno, col, True)  # Pyright warning: str not assignable to int
-            record.levelname = self.colorize(levelname, col, True)
-            record.msg = self.colorize(record.msg, col)
+        if self.use_color:
+            levelname = record.levelname
+            if levelname in ColoredFormatter.COLORS:
+                col = ColoredFormatter.COLORS[levelname]
+                record.name = self.colorize(record.name, col, True)
+                record.levelname = self.colorize(levelname, col, True)
+                record.msg = self.colorize(record.msg, col)
         return logging.Formatter.format(self, record)
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -125,8 +125,15 @@ class TestProgressReporter:
     """Test ProgressReporter functionality."""
 
     def test_initial_state(self):
-        """Test initial progress reporter state."""
-        reporter = ProgressReporter()
+        """Test initial progress reporter state.
+
+        Defaults follow ``sys.stdout.isatty()``: progress / status are
+        auto-disabled when not running on a TTY (CI, pipes).  Force
+        TTY here so the assertion is environment-independent.
+        """
+        with patch("sys.stdout") as mock_stdout:
+            mock_stdout.isatty = lambda: True
+            reporter = ProgressReporter()
 
         assert reporter.enabled
         assert reporter.use_symbols
@@ -170,6 +177,7 @@ class TestProgressReporter:
 
         with patch("sys.stdout", mock_stdout):
             reporter = ProgressReporter()
+            reporter.enabled = True  # StringIO is not a TTY; force on for test
             result = Result(Point(np.array([1.0, 2.0]), "test"), 5.0, None, None, False)
             context = ProgressContext()
 
@@ -186,6 +194,8 @@ class TestProgressReporter:
 
         with patch("sys.stdout", mock_stdout):
             reporter = ProgressReporter()
+            reporter.enabled = True  # StringIO is not a TTY; force on for test
+            reporter.status_enabled = True
             reporter.status_line_printed = True  # Simulate that status line exists
 
             reporter.update_status(
@@ -264,6 +274,8 @@ class TestProgressReporterIntegration:
             mock_stdout.isatty = lambda: False
 
             reporter = ProgressReporter()
+            reporter.enabled = True  # force-on; default would be off for non-TTY
+            reporter.status_enabled = True
             assert not reporter.supports_ansi  # Should detect non-TTY
 
             result1 = Result(Point(np.array([1.0, 2.0]), "test1"), 5.0, None, None, False)


### PR DESCRIPTION
## Summary

Reduces the CI log noise from the nightly self-improvement workflow by auto-detecting non-TTY contexts and suppressing output that only makes sense for live human viewing.

Three noise sources fixed:

1. **`ProgressReporter`** printed one progress char + status line per evaluation regardless of TTY → now auto-disabled when `sys.stdout.isatty()` is False.
2. **`ColoredFormatter`** unconditionally injected ANSI color codes → now skips colorization when `sys.stderr.isatty()` is False. The fmt string also drops the `\$BOLD ... \$RESET` markers in that mode.
3. **`actions/checkout@v4` with `fetch-depth: 0`** listed every remote branch (~100 lines of `* [new branch] ...` in the log) → switched to default shallow checkout.

## What was in the log before vs. after

The previous test run's `Run self-improvement loop` step looked like:

```
0.053265 config:199      ^[[1m^[[1;37mCONFG^[[0m    ^[[0m ^[[1;37mINFO^[[0m      ^[[0;37mconfig.yaml loaded...
[self_improve] iter=0 measuring baseline
🎉🎉.....🎉...................🎊..🎊.........
[ Evals: 0% (0/75)  |  ETA: 0s  |  Convergence: 0%  |  Best: 0.00e+00 ]
....................
[ Evals: 80% (60/75)  |  ETA: 0s  |  Convergence: 80%  |  Best: 3.2094 ]
🎉🎉..🎉....🎉.............................🎊
... (×N for every evaluation × every spec × every iteration)
```

After this PR the same step should show plain log lines (config / iteration messages only), no per-evaluation progress chars, no ANSI escape sequences.

## Compatibility

Callers that *want* progress in a log can still:
- pass `progress_enabled=True` in the `PanobbgoLogger` config dict, or
- set `reporter.enabled = True` directly after construction, or
- call `logger.enable_progress_reporting()` (used by `set_verbose_mode`).

The existing CLI / library API is unchanged.

## Tests

- `tests/test_logging.py`: four tests that build `ProgressReporter()` inside a `patch("sys.stdout", StringIO())` block (StringIO reports `isatty()` as False) now either mock `isatty` to True or set `.enabled = True` explicitly. Matches the existing pattern in `test_ansi_mode_output_sequence`.
- Full suite locally: **990 passed, 1 skipped, 5 warnings** (preexisting Sobol / sklearn).

## Test plan

- [ ] Verify CI green on this PR.
- [ ] After merge: manually trigger Nightly Self-Improvement Loop with `iterations=2, mode=quick` and confirm the log is dramatically shorter — no progress chars, no ANSI escapes, no branch-list spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)