### PR TITLE
feat(self_improve): multi-seed hold-out for robust drift estimation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,13 @@ The harness is the measurement substrate for an autonomous
     drawn from a completely independent ``base_seed`` SHA-256 stream;
     a shrinking ``top - seed`` gap (``drift < -eps_overfit``) flags
     overfit to the training base_seed family — the failure mode the
-    anti-cherry-pick guard cannot see.
+    anti-cherry-pick guard cannot see.  Multi-seed hold-out
+    (**shipped 2026-05-16**) extends this with
+    `LoopConfig.holdout_base_seeds` (list-typed) and
+    `--holdout-base-seeds 1234,5678,9012`: one record per seed is
+    written and the CLI aggregates with worst-case drift /
+    any-overfit semantics — a more robust generalisation check
+    than a single independent draw.
 *   Categorical mutation rule — **shipped**, see
     `panobbgo.self_improve.MutationRule` with
     `kind="categorical_choice"`.  Picks uniformly from a discrete
@@ -284,6 +290,13 @@ uv run python scripts/self_improve.py run --iterations 100 \
 # fail with exit code 3 if the ladder is flagged as overfit
 uv run python scripts/self_improve.py run --iterations 100 \
     --mode standard --holdout-base-seed 1234 --fail-on-overfit
+
+# Multi-seed hold-out: more robust drift estimate over several
+# independent SHA-256 streams.  Worst-case drift across seeds is
+# reported; --fail-on-overfit fires if any single seed flags overfit.
+uv run python scripts/self_improve.py run --iterations 100 \
+    --mode standard --holdout-base-seeds 1234,5678,9012 \
+    --fail-on-overfit
 
 # Inspect the ledger
 uv run python scripts/self_improve.py summary

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,80 @@
 
 ## Recent Improvements (continued)
 
+### Multi-Seed Hold-Out Validation (2026-05-16)
+- [x] **New `panobbgo.self_improve.LoopConfig.holdout_base_seeds`** —
+      list-typed sibling of the scalar `holdout_base_seed` shipped
+      2026-05-08; closes the *Multi-seed hold-out for robust drift
+      estimation* follow-up in `planning/SELF_IMPROVEMENT_LOOP.md`.
+      At the end of every loop run, one `LoopHoldoutRecord` is
+      written per seed in the list and the CLI aggregates with
+      worst-case drift (`min`) and any-overfit (`any`) semantics —
+      strictly more conservative than the single-seed check.
+  - **Why it matters.**  The single-seed hold-out reduces the
+    entire generalisation question to one independent SHA-256
+    draw.  When a ladder overfits in a subtle way — for example,
+    exploiting a quirk that happens to repeat across the chosen
+    hold-out seed — that one draw can miss it.  Aggregating over
+    several seeds catches the failure mode the single seed
+    misses while remaining cheap relative to the training cost.
+- [x] **`LoopConfig.resolved_holdout_seeds()`** helper — single
+      branch that returns the effective seed tuple (list when
+      non-empty, else scalar promoted to a 1-tuple, else `()` =
+      disabled).  Keeps the multi-seed loop driver simple while
+      preserving back-compat for scalar callers.
+- [x] **`LoopConfig.holdout_harness_config(..., base_seed=None)`** —
+      optional `base_seed` argument drives `HarnessConfig.seed`
+      per call rather than reading the scalar attribute.  Without
+      this wiring, the multi-seed loop would still measure against
+      the scalar.
+- [x] **`SelfImprover._run_holdout(ladder, base_seed, verbose)`**
+      now takes the seed as a parameter; the main loop iterates
+      over `resolved_holdout_seeds()` and writes one record per
+      seed to the ledger.  `record_type='holdout'` is unchanged, so
+      existing ledger consumers see N records back-to-back instead
+      of one.
+- [x] **CLI flag `--holdout-base-seeds`** on
+      `scripts/self_improve.py run`.  Accepts a comma-separated
+      list (e.g. `1234,5678,9012`); the parser tolerates whitespace
+      around entries and trailing commas, and rejects non-integer
+      tokens with a clear error.  The end-of-run summary line and
+      the `summary` subcommand both report the aggregated verdict:
+      `OVERFIT` if any record flagged overfit, worst (most negative)
+      drift across seeds.
+- [x] **Validation rules** — `LoopConfig.__post_init__` rejects
+      `0` entries (the disable sentinel), collision with
+      `base_seed`, and duplicates in the list.  Each rule has a
+      distinct error message.  Normalises `List[int]` input to
+      `Tuple[int, ...]` for hash / equality stability.
+- [x] **25 new tests in `tests/test_self_improve.py`** (total 147):
+      - **`TestLoopConfigMultiSeedHoldout`** — default empty tuple,
+        list/tuple normalization, zero entry rejected, collision
+        with base_seed rejected, duplicates rejected,
+        `resolved_holdout_seeds()` precedence (list > scalar >
+        empty), `holdout_harness_config()` explicit-seed override
+        and default-to-scalar.
+      - **`TestSelfImproverMultiSeedHoldout`** — one record per
+        seed in configured order, per-seed harness seeds reach
+        the factory, overfit flagged independently per seed,
+        list-wins-over-scalar precedence, all records written to
+        JSONL ledger, scalar back-compat path unaffected, disable
+        when both knobs unset.
+      - **`TestCliSeedListParser`** — empty / whitespace / single
+        / multiple / whitespace-tolerant / negative-accepted /
+        non-integer-rejected / trailing-comma-skipped paths.
+- [x] **Documentation updated**
+  - `planning/SELF_IMPROVEMENT_LOOP.md`: §2 missing-pieces list
+    extended; Phase 6 checklist updated; new §13 dated entry; the
+    *Multi-seed hold-out* follow-up promoted from "open" to
+    "shipped".
+  - `doc/source/guide_benchmarking.rst`: new "Multi-seed hold-out"
+    subsection with the aggregation rule, validation rules, CLI
+    example, and programmatic example.
+  - `doc/source/guide.rst`: quick-nav entry mentions the
+    multi-seed hold-out.
+  - `AGENTS.md`: self-improvement loop subsection lists the
+    multi-seed feature with a run-the-loop bash example.
+
 ### Categorical Mutation Rule (`categorical_choice`) (2026-05-13)
 - [x] **New `MutationRule(kind="categorical_choice", choices=...)`**
       in `panobbgo/self_improve.py`.  Fourth mutation kind alongside

--- a/doc/source/guide.rst
+++ b/doc/source/guide.rst
@@ -41,7 +41,7 @@ Quick Navigation
    * - **Interested in research?**
      - Explore :doc:`guide_research` for related work, theoretical properties, and future directions
    * - **Want to measure progress?**
-     - Read :doc:`guide_benchmarking` for the composite score, external baselines, parametrically randomised problems, the statistical acceptance rule, the autonomous self-improvement loop driver, the anti-cherry-pick guard, the hold-out validation set, the adaptive Thompson-sampling mutation sampler, the structural ``add_heuristic`` / ``drop_heuristic`` portfolio mutations, the categorical ``MutationRule`` kind (for discrete knobs like ``PSO.topology``, ``Sobol.scramble``, and ``LSHADE.archive_factor``), the dual-topology PSO (``gbest`` / ``lbest``) candidate pool, the L-SHADE adaptive Differential Evolution heuristic (Tanabe-Fukunaga 2014), and the COBYQA derivative-free trust-region local optimizer (Ragonneau-Zhang 2023)
+     - Read :doc:`guide_benchmarking` for the composite score, external baselines, parametrically randomised problems, the statistical acceptance rule, the autonomous self-improvement loop driver, the anti-cherry-pick guard, the hold-out validation set (single- and multi-seed), the adaptive Thompson-sampling mutation sampler, the structural ``add_heuristic`` / ``drop_heuristic`` portfolio mutations, the categorical ``MutationRule`` kind (for discrete knobs like ``PSO.topology``, ``Sobol.scramble``, and ``LSHADE.archive_factor``), the dual-topology PSO (``gbest`` / ``lbest``) candidate pool, the L-SHADE adaptive Differential Evolution heuristic (Tanabe-Fukunaga 2014), and the COBYQA derivative-free trust-region local optimizer (Ragonneau-Zhang 2023)
 
 Guide Contents
 --------------

--- a/doc/source/guide_benchmarking.rst
+++ b/doc/source/guide_benchmarking.rst
@@ -918,6 +918,74 @@ family; the hold-out runs once at the end and catches overfit to the
 training base_seed family itself.  Together they cover the two main
 overfitting modes the loop can suffer from.
 
+Multi-seed hold-out
+^^^^^^^^^^^^^^^^^^^
+
+The single-base-seed hold-out described above reduces the entire
+generalisation question to one independent draw.  When a ladder
+overfits in a subtle way — for example, the accepted mutation
+exploits a quirk that happens to repeat across the chosen hold-out
+seed — that one draw can miss it.
+
+The list-typed
+:attr:`~panobbgo.self_improve.LoopConfig.holdout_base_seeds` knob
+trades that single point estimate for a worst-case estimate over
+several independent SHA-256 streams.  At the end of the loop, one
+:class:`~panobbgo.self_improve.LoopHoldoutRecord` is written per seed
+in the list.  The CLI then aggregates:
+
+* **overfit** ⟺ ``any(record.overfit for record in records)``
+* **worst drift** is the smallest (most negative) ``drift`` across
+  seeds.
+
+This is strictly more conservative than the single-seed check: one
+bad seed flags the ladder, even when the average drift across seeds
+is comfortably positive.  Cost scales linearly with the number of
+seeds (each seed adds ``2 × holdout_iterations`` harness runs at the
+end of the loop), still small relative to a typical training-loop
+budget.
+
+When both ``holdout_base_seed`` (scalar) and ``holdout_base_seeds``
+(list) are configured, the list wins and the scalar is silently
+ignored — the list is the "do exactly this" override.
+
+Validation rules:
+
+* Every list entry must be non-zero (``0`` is the disable sentinel).
+* Every list entry must differ from
+  :attr:`~panobbgo.self_improve.LoopConfig.base_seed`.
+* List entries must be distinct (duplicates would re-measure the
+  same stream).
+
+CLI:
+
+.. code-block:: bash
+
+   # 3-seed hold-out: worst drift across 1234 / 5678 / 9012 is the
+   # number the CLI reports; overfit flags if any seed regresses.
+   uv run python scripts/self_improve.py run --iterations 50 \
+       --mode standard --holdout-base-seeds 1234,5678,9012 \
+       --fail-on-overfit
+
+Programmatic use:
+
+.. code-block:: python
+
+   cfg = LoopConfig(
+       iterations=50,
+       mode="standard",
+       holdout_base_seeds=(1234, 5678, 9012),
+       holdout_iterations=5,
+   )
+   iter_records, guard_records, holdout_records = (
+       SelfImprover(cfg).run_full()
+   )
+   any_overfit = any(r.overfit for r in holdout_records)
+   worst_drift = min(r.drift for r in holdout_records)
+   if any_overfit:
+       print(f"WARNING: ladder overfits at least one hold-out seed"
+             f" (worst drift={worst_drift:+.4f})")
+
 
 Extending the harness
 ---------------------

--- a/panobbgo/self_improve.py
+++ b/panobbgo/self_improve.py
@@ -97,12 +97,14 @@ peculiarities of the training base-seed family will *not* be caught: the
 guard's "fresh" instances are drawn from the same SHA-256 stream.
 
 The hold-out validation closes that gap.  At the **end** of the loop run
-(once :attr:`LoopConfig.iterations` are exhausted), if
-:attr:`LoopConfig.holdout_base_seed` is non-zero and
+(once :attr:`LoopConfig.iterations` are exhausted), if at least one
+hold-out base seed is configured (either the scalar
+:attr:`LoopConfig.holdout_base_seed` or the list-typed
+:attr:`LoopConfig.holdout_base_seeds`) and
 :attr:`LoopConfig.holdout_iterations` is positive, the loop re-measures
-both the **seed** ladder entry and the **final top** entry on a
-completely independent ``base_seed`` family.  The two scores are
-averaged over ``holdout_iterations`` distinct instances and compared
+both the **seed** ladder entry and the **final top** entry on each
+completely independent ``base_seed`` family.  Per seed, the two scores
+are averaged over ``holdout_iterations`` distinct instances and compared
 to the training-time scores recorded on the ladder.  If the
 "top minus seed" gap on the hold-out is smaller than the training gap
 by more than :attr:`LoopConfig.holdout_eps_overfit`, the loop emits an
@@ -110,11 +112,21 @@ by more than :attr:`LoopConfig.holdout_eps_overfit`, the loop emits an
 CLI when ``--fail-on-overfit`` is set.  Otherwise the record is written
 informationally so an auditor can inspect the generalisation drift.
 
+When multiple seeds are configured via :attr:`LoopConfig.holdout_base_seeds`,
+one :class:`LoopHoldoutRecord` is written per seed and the CLI aggregates
+them into a single verdict line — ``overfit`` if **any** seed flagged
+overfit, and the **worst** (most negative) drift across seeds.  This
+makes the hold-out a more robust drift estimator: a single hold-out seed
+reduces the entire generalisation question to one independent draw, but
+several seeds catch overfits that escape any one draw while remaining
+cheap relative to the loop's training cost.
+
 Hold-out is one-shot at the end of the loop and uses fresh randomized
-instances, so its compute cost is fixed:
-``2 × holdout_iterations`` harness runs — typically a small fraction
-of the loop's total budget.  Disabled by default
-(``holdout_base_seed = 0``) so existing configurations behave identically.
+instances, so its compute cost is fixed per seed:
+``2 × holdout_iterations`` harness runs per seed — typically a small
+fraction of the loop's total budget.  Disabled by default
+(``holdout_base_seed = 0`` and ``holdout_base_seeds = ()``) so existing
+configurations behave identically.
 
 Safety rails (§8 in the plan)
 -----------------------------
@@ -1480,11 +1492,23 @@ class LoopConfig:
             resuming a long unattended run.
         holdout_base_seed: Independent ``base_seed`` used for the
             end-of-loop hold-out validation.  ``0`` (default) disables
-            hold-out entirely.  Should differ from :attr:`base_seed` —
-            using the same value collapses the hold-out check to the
-            anti-cherry-pick guard with offset ``0`` and is rejected at
-            validation time.  See "Hold-out validation set" in the module
-            docstring for the full rationale.
+            hold-out entirely (unless :attr:`holdout_base_seeds` is set).
+            Should differ from :attr:`base_seed` — using the same value
+            collapses the hold-out check to the anti-cherry-pick guard
+            with offset ``0`` and is rejected at validation time.  See
+            "Hold-out validation set" in the module docstring for the full
+            rationale.  This scalar knob is retained for back-compat;
+            multi-seed callers should prefer :attr:`holdout_base_seeds`.
+        holdout_base_seeds: Multi-seed hold-out validation.  Each entry is
+            an independent ``base_seed`` value the loop will re-measure
+            the ladder against at the end of the run.  Empty tuple
+            (default) means "fall back to the scalar
+            :attr:`holdout_base_seed`".  When non-empty, the scalar is
+            ignored.  Reducing across the per-seed records uses ``min``
+            on drift (worst-case generalisation) and ``any`` on overfit
+            (one bad seed flags the ladder).  All entries must differ
+            from :attr:`base_seed` and from one another; ``0`` is not a
+            valid entry (use the empty tuple to disable).
         holdout_iterations: Number of distinct ``randomize_iteration``
             values to average over when computing the hold-out composite
             for both the seed and the top ladder entries.  Must be
@@ -1527,6 +1551,7 @@ class LoopConfig:
     adaptive_prior_beta: float = 1.0
     adaptive_prime_from_ledger: bool = False
     holdout_base_seed: int = 0
+    holdout_base_seeds: Tuple[int, ...] = ()
     holdout_iterations: int = 5
     holdout_iteration_offset: int = 0
     holdout_eps_overfit: float = 0.05
@@ -1557,6 +1582,30 @@ class LoopConfig:
                 f"holdout_base_seed must differ from base_seed (both={self.base_seed});"
                 " hold-out is meant to draw from a *different* SHA-256 stream"
             )
+        # Normalize a list/sequence argument into a tuple so callers may pass
+        # either a tuple or a list and the dataclass stays hashable-safe.
+        # ``Sequence[int]`` would type the field correctly but a tuple is
+        # the simplest concrete shape the rest of the code relies on.
+        self.holdout_base_seeds = tuple(int(s) for s in self.holdout_base_seeds)
+        if self.holdout_base_seeds:
+            # Per-entry constraints: no 0 sentinel, no collision with the
+            # training base_seed, and no duplicates within the list.  Each
+            # rule has a distinct failure mode the user should hear about.
+            if any(s == 0 for s in self.holdout_base_seeds):
+                raise ValueError(
+                    "holdout_base_seeds entries must be non-zero; pass an empty tuple to disable multi-seed hold-out"
+                )
+            collisions = [s for s in self.holdout_base_seeds if s == self.base_seed]
+            if collisions:
+                raise ValueError(
+                    f"holdout_base_seeds must differ from base_seed (overlap={collisions});"
+                    " hold-out is meant to draw from *different* SHA-256 streams"
+                )
+            if len(set(self.holdout_base_seeds)) != len(self.holdout_base_seeds):
+                raise ValueError(
+                    f"holdout_base_seeds must be distinct, got {list(self.holdout_base_seeds)};"
+                    " duplicates would just re-measure the same SHA-256 stream"
+                )
 
     def harness_config(
         self,
@@ -1580,25 +1629,43 @@ class LoopConfig:
         self,
         strategies_override: List[StrategySpec],
         iteration_id: int,
+        base_seed: Optional[int] = None,
     ) -> HarnessConfig:
         """Build the :class:`HarnessConfig` used by hold-out validation.
 
         Identical to :meth:`harness_config` except that ``seed`` is taken
-        from :attr:`holdout_base_seed`.  This swaps the SHA-256 instance
-        stream wholesale, giving the hold-out a genuinely independent set
-        of randomized problems.
+        either from the explicit ``base_seed`` argument (used by the
+        multi-seed path) or from :attr:`holdout_base_seed` when not
+        provided.  This swaps the SHA-256 instance stream wholesale,
+        giving the hold-out a genuinely independent set of randomized
+        problems.
         """
         return HarnessConfig(
             mode=self.mode,
             budget=self.budget,
             reps=self.reps,
-            seed=self.holdout_base_seed,
+            seed=self.holdout_base_seed if base_seed is None else int(base_seed),
             strategies=self.strategy_names,
             timeout_per_run=self.timeout_per_run,
             randomize=self.randomize,
             randomize_iteration=iteration_id,
             strategies_override=strategies_override,
         )
+
+    def resolved_holdout_seeds(self) -> Tuple[int, ...]:
+        """Effective tuple of hold-out base seeds.
+
+        Multi-seed (:attr:`holdout_base_seeds`) wins when set so callers
+        opting into the list don't have to also clear the scalar.  Otherwise
+        the scalar :attr:`holdout_base_seed` is promoted to a 1-tuple when
+        non-zero, or the empty tuple when both knobs are at their defaults
+        (= hold-out disabled).
+        """
+        if self.holdout_base_seeds:
+            return self.holdout_base_seeds
+        if self.holdout_base_seed != 0:
+            return (int(self.holdout_base_seed),)
+        return ()
 
 
 @dataclass
@@ -2084,13 +2151,18 @@ class SelfImprover:
         # the loop never produced a baseline measurement, or when the
         # battery is non-randomized (in which case a different base_seed
         # would not change the instances and the check is meaningless).
+        # When multiple hold-out seeds are configured we write one
+        # :class:`LoopHoldoutRecord` per seed so an auditor can inspect
+        # per-seed generalisation; aggregation across seeds is left to
+        # the CLI summary path.
         if self._holdout_enabled() and len(records) > 0:
-            holdout_record = self._run_holdout(ladder, verbose)
-            if holdout_record is not None:
-                holdout_records.append(holdout_record)
-                ledger.write(holdout_record)
-                if verbose:
-                    self._print_holdout(holdout_record)
+            for ho_seed in self.config.resolved_holdout_seeds():
+                holdout_record = self._run_holdout(ladder, ho_seed, verbose)
+                if holdout_record is not None:
+                    holdout_records.append(holdout_record)
+                    ledger.write(holdout_record)
+                    if verbose:
+                        self._print_holdout(holdout_record)
 
         return records, guard_records, holdout_records
 
@@ -2293,13 +2365,15 @@ class SelfImprover:
     def _holdout_enabled(self) -> bool:
         """Return True iff the hold-out validation is configured to run.
 
-        Three knobs gate this: an independent ``base_seed``, a positive
+        Three knobs gate this: at least one independent ``base_seed``
+        (via the scalar :attr:`LoopConfig.holdout_base_seed` or the
+        list-typed :attr:`LoopConfig.holdout_base_seeds`), a positive
         iteration count, and the randomized battery itself — without
         randomization a different ``base_seed`` does not produce
         different instances and the check would be vacuous.
         """
         return (
-            int(self.config.holdout_base_seed) != 0
+            len(self.config.resolved_holdout_seeds()) > 0
             and int(self.config.holdout_iterations) > 0
             and bool(self.config.randomize)
         )
@@ -2308,18 +2382,20 @@ class SelfImprover:
         self,
         specs: List[StrategySpec],
         iteration_id: int,
+        base_seed: int,
         label: str,
         verbose: bool,
     ) -> HarnessResult:
-        """Single hold-out measurement on the independent base_seed."""
-        hc = self.config.holdout_harness_config(specs, iteration_id)
+        """Single hold-out measurement on an independent ``base_seed``."""
+        hc = self.config.holdout_harness_config(specs, iteration_id, base_seed=base_seed)
         if verbose:
-            print(f"[self_improve] hold-out measuring {label} at iter_id={iteration_id}")
+            print(f"[self_improve] hold-out measuring {label} at iter_id={iteration_id} base_seed={base_seed}")
         return self._harness_factory(hc).run(verbose=False)
 
     def _run_holdout(
         self,
         ladder: List[LadderEntry],
+        base_seed: int,
         verbose: bool,
     ) -> Optional["LoopHoldoutRecord"]:
         """Re-measure seed and top of the ladder on an independent base_seed.
@@ -2330,6 +2406,11 @@ class SelfImprover:
         ``overfit`` flag is set when the on-hold-out improvement gap
         falls more than :attr:`LoopConfig.holdout_eps_overfit` short of
         the on-training gap.
+
+        ``base_seed`` is the per-call hold-out seed — when only the
+        scalar :attr:`LoopConfig.holdout_base_seed` is set this is that
+        value, otherwise it cycles through
+        :attr:`LoopConfig.holdout_base_seeds`.
         """
         if not ladder:
             return None
@@ -2346,12 +2427,12 @@ class SelfImprover:
 
         for k in range(n_iters):
             iter_id = offset + k
-            seed_result = self._measure_holdout(seed_entry.specs, iter_id, "seed", verbose)
+            seed_result = self._measure_holdout(seed_entry.specs, iter_id, base_seed, "seed", verbose)
             seed_scores.append(float(seed_result.composite_score))
             if seed_only:
                 top_scores.append(seed_scores[-1])
             else:
-                top_result = self._measure_holdout(top_entry.specs, iter_id, "top", verbose)
+                top_result = self._measure_holdout(top_entry.specs, iter_id, base_seed, "top", verbose)
                 top_scores.append(float(top_result.composite_score))
 
         seed_holdout = float(np.mean(seed_scores)) if seed_scores else 0.0
@@ -2395,7 +2476,7 @@ class SelfImprover:
         return LoopHoldoutRecord(
             timestamp=datetime.now(tz=timezone.utc).isoformat(),
             duration_seconds=time.time() - start,
-            holdout_base_seed=int(self.config.holdout_base_seed),
+            holdout_base_seed=int(base_seed),
             holdout_iterations=n_iters,
             holdout_iteration_offset=offset,
             seed_holdout_score=seed_holdout,

--- a/planning/SELF_IMPROVEMENT_LOOP.md
+++ b/planning/SELF_IMPROVEMENT_LOOP.md
@@ -77,7 +77,11 @@ What's missing for a true self-improvement loop:
       End-of-loop re-measure on an *independent* `base_seed`
       catches overfit to the training base_seed family that the
       anti-cherry-pick guard cannot see.  CLI: `--holdout-base-seed`,
-      `--fail-on-overfit`.
+      `--fail-on-overfit`.  Extended 2026-05-16 with multi-seed
+      hold-out — `LoopConfig.holdout_base_seeds` is a list of
+      independent seeds; one `LoopHoldoutRecord` is written per seed
+      and the CLI aggregates with worst-case drift / any-overfit
+      semantics.  CLI: `--holdout-base-seeds 1234,5678,9012`.
 
 ## 3. Architecture of the loop
 
@@ -416,6 +420,11 @@ Each phase is independently deliverable and keeps the framework usable.
       *independent* ``base_seed`` SHA-256 stream catches overfit to
       the training base_seed family — the failure mode the guard
       cannot see (the guard varies only ``randomize_iteration``).
+      Extended 2026-05-16 with multi-seed hold-out via
+      :attr:`LoopConfig.holdout_base_seeds` (list-typed) and
+      ``--holdout-base-seeds 1234,5678,9012``; the CLI aggregates
+      per-seed records with worst-case drift / any-overfit
+      semantics (see §13 entry).
 - [ ] Broaden further: analyzer add/drop, swapping a strategy class
       itself (e.g., ``StrategyRewarding`` → ``StrategyUCB``).
 - [x] Stratified dimension sampling (§10) for cross-iteration score
@@ -574,6 +583,96 @@ This section records direct algorithmic improvements applied to Panobbgo
 *outside* of the autonomous loop, so the human-in-the-loop history stays
 greppable.  Each entry should reference the PR / commit that landed it,
 the rationale, and a measured-impact number when available.
+
+### 2026-05-16 — Multi-seed hold-out for robust drift estimation
+
+* **What** — `panobbgo/self_improve.py`:
+  :class:`LoopConfig` gains a list-typed
+  ``holdout_base_seeds: Tuple[int, ...]`` field (default ``()``)
+  that sits alongside the scalar ``holdout_base_seed`` shipped
+  2026-05-08.  A new helper :meth:`LoopConfig.resolved_holdout_seeds`
+  returns the effective seed tuple: the list when non-empty, else
+  the scalar promoted to a 1-tuple, else ``()`` (= disabled).
+  :meth:`LoopConfig.holdout_harness_config` gains an optional
+  ``base_seed`` argument so the multi-seed loop can drive the
+  ``HarnessConfig.seed`` per call rather than reading it from the
+  config attribute.  :class:`SelfImprover._run_holdout` similarly
+  takes ``base_seed`` as a parameter (formerly read from
+  ``self.config.holdout_base_seed``) and :class:`SelfImprover._run_internal`
+  iterates over the resolved tuple, writing one
+  :class:`LoopHoldoutRecord` per seed to the ledger.  The
+  ``record_type='holdout'`` tag is unchanged, so existing ledger
+  consumers see N records back-to-back per loop run instead of one.
+  ``scripts/self_improve.py`` gains a ``--holdout-base-seeds``
+  flag that accepts a comma-separated list (e.g.
+  ``--holdout-base-seeds 1234,5678,9012``); the parser tolerates
+  whitespace and trailing commas and rejects non-integer tokens
+  with a clear error.  The CLI's end-of-run summary line and the
+  ``summary`` subcommand both report the aggregated verdict:
+  ``OVERFIT`` if *any* per-seed record flagged overfit, with the
+  *worst* (most negative) drift across seeds.
+* **Why** — closes the *Multi-seed hold-out for robust drift
+  estimation* follow-up below.  The single-seed hold-out shipped
+  2026-05-08 reduces the entire generalisation question to one
+  independent SHA-256 draw, and a single recent ledger run
+  produced ``drift=-0.0074`` (well within the default
+  ``eps_overfit=0.05``, but on a single draw it is hard to know
+  whether ``-0.0074`` is the typical drift or the lucky tail of a
+  larger one).  Multi-seed aggregation gives a worst-case
+  estimate over several independent draws — strictly more
+  conservative — at a cost that scales linearly with the seed
+  list and stays small relative to the loop's training budget.
+  The reduction matches the planning doc's request: ``min`` over
+  drifts, ``any`` over overfit flags.
+* **Backwards compatibility** — strictly safe.  The default for
+  ``holdout_base_seeds`` is the empty tuple; existing callers that
+  set only ``holdout_base_seed`` see exactly one
+  :class:`LoopHoldoutRecord` as before.  ``resolved_holdout_seeds()``
+  promotes a scalar to a 1-tuple, so the multi-seed code path
+  handles both cases through one branch.  When both are set, the
+  list takes precedence (the explicit "do exactly this" override)
+  and the scalar is silently ignored.  No existing ledger or
+  ledger consumer is affected; the new records share the same
+  schema as the single-seed record and the same ``record_type``
+  tag.
+* **Validation** — three rules at config construction time, with
+  distinct error messages: no zero entries (``0`` is the disable
+  sentinel), no collision with ``base_seed``, no duplicates.  The
+  CLI parser also tolerates ``"1234, 5678 , 9012"`` and trailing
+  commas so common copy/paste inputs don't trip the user.
+* **Cost** — fixed at ``2 × holdout_iterations × len(seeds)``
+  harness runs at the end of the loop (or
+  ``holdout_iterations × len(seeds)`` when the ladder has only
+  the seed entry — both endpoints are the same spec list).  At
+  the standard ``holdout_iterations=5`` with 3 seeds that is 30
+  extra harness runs, small relative to the ``2 × iterations``
+  cost of a typical 50-iteration loop.
+* **Tests** — `tests/test_self_improve.py` (25 new tests, total 147):
+  config validation (default empty tuple, list/tuple normalization,
+  zero entry rejected, collision with base_seed rejected,
+  duplicates rejected), :meth:`resolved_holdout_seeds` (list
+  precedence, scalar fallback, empty fallback),
+  :meth:`holdout_harness_config` explicit-seed override and
+  default-to-scalar paths, end-to-end behaviour (one record per
+  seed in configured order, per-seed harness seeds reach the
+  factory, overfit flagged independently per seed, list-wins-over-
+  scalar precedence, all records written to JSONL ledger, scalar
+  back-compat path unaffected, disable when both knobs unset), and
+  the CLI parser (empty / whitespace / single / multiple /
+  whitespace-tolerant / negative-accepted / non-integer-rejected /
+  trailing-comma-skipped paths — 8 tests).
+* **Documentation updated**
+  - `planning/SELF_IMPROVEMENT_LOOP.md`: this §13 entry; the
+    *Multi-seed hold-out for robust drift estimation* follow-up
+    promoted from "open" to "shipped".
+  - `doc/source/guide_benchmarking.rst`: new "Multi-seed hold-out"
+    subsection under "Hold-out validation set" with the
+    aggregation rule, validation rules, CLI example, and
+    programmatic example.
+  - `doc/source/guide.rst`: quick-nav entry mentions the multi-seed
+    hold-out.
+  - `AGENTS.md`: self-improvement loop subsection lists the
+    multi-seed feature with a run-the-loop bash example.
 
 ### 2026-05-13 — Categorical mutation rule (`categorical_choice`)
 
@@ -1452,27 +1551,28 @@ motivate the work:
   instance's ``scale`` kwarg without going through the full
   ``add_heuristic`` / ``drop_heuristic`` cycle.
 
-#### Multi-seed hold-out for robust drift estimation
+#### Multi-seed hold-out for robust drift estimation — shipped 2026-05-16
 
-The single-base-seed hold-out shipped 2026-05-08 catches overfit to
-the *training* base_seed family but reduces the entire generalisation
-question to one independent draw.  A natural upgrade is to evaluate
-the ladder on *several* independent ``holdout_base_seed`` values
-(e.g. ``[1234, 5678, 9012]``) and report the *worst* drift across
-them.  Needs:
+Multi-seed hold-out shipped 2026-05-16 as
+:attr:`panobbgo.self_improve.LoopConfig.holdout_base_seeds` (the
+list-typed sibling of the scalar ``holdout_base_seed``) and the
+``--holdout-base-seeds`` CLI flag.  See the §13 entry.  Natural
+follow-ups when the loop has collected enough evidence to motivate
+the work:
 
-- A list-typed ``holdout_base_seeds`` knob (``int | List[int]``)
-  alongside the current scalar.
-- A reduction over the per-seed records (``min`` of drift, ``any``
-  of overfit) into a single CLI summary line.
-- Bootstrap CI on the drift estimate would be the next step beyond
-  that — turning the hold-out into a statistical test rather than
-  a point check.
-
-Cost scales linearly with the number of seeds; for a typical 5-seed
-hold-out at ``holdout_iterations=5`` that is ``2 × 5 × 5 = 50``
-extra harness runs at the end of the loop, still small compared to
-a typical ``2 × 100`` iteration loop.
+- **Bootstrap CI on the drift estimate** — today the multi-seed
+  reduction is ``min`` over drifts and ``any`` over overfit flags.
+  A natural upgrade is to bootstrap the per-seed drift values and
+  emit a confidence interval on the *aggregate* drift, turning the
+  hold-out into a statistical test rather than a point check.  This
+  pairs naturally with the :func:`statistical_accept`-style decision
+  rules already used inside the loop.
+- **Auto-rollback on multi-seed overfit** — when several seeds
+  agree the ladder is overfit, the loop could automatically pop the
+  ladder back to the seed and penalise the bandit (see
+  *Auto-rollback on hold-out overfit* below).  Multi-seed evidence
+  is strong enough to act on, whereas single-seed evidence might
+  still be a fluke.
 
 #### Auto-rollback on hold-out overfit
 

--- a/scripts/self_improve.py
+++ b/scripts/self_improve.py
@@ -70,6 +70,17 @@ Two subcommands:
         uv run python scripts/self_improve.py run --iterations 50 \\
             --holdout-base-seed 1234 --fail-on-overfit
 
+``--holdout-base-seeds``
+    Multi-seed variant of ``--holdout-base-seed``.  Pass a comma-separated
+    list of integers; one :class:`LoopHoldoutRecord` is written per seed
+    and the CLI prints a single aggregated verdict (``OVERFIT`` if any
+    seed flagged overfit; worst drift across seeds).  Strictly more
+    robust than the single-seed check at the cost of one extra
+    ``2 × holdout_iterations`` runs per added seed::
+
+        uv run python scripts/self_improve.py run --iterations 50 \\
+            --holdout-base-seeds 1234,5678,9012 --fail-on-overfit
+
 Stop the loop early by ``touch STOP_SELF_IMPROVE`` (configurable via
 ``--stop-sentinel``); the current iteration will finish, then the loop
 exits and the ledger is preserved.
@@ -266,6 +277,21 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Independent base_seed for end-of-loop hold-out validation."
             " Default 0 disables hold-out.  Must differ from --base-seed."
+            " Ignored when --holdout-base-seeds is set."
+        ),
+    )
+    run_p.add_argument(
+        "--holdout-base-seeds",
+        dest="holdout_base_seeds",
+        type=str,
+        default="",
+        metavar="S1,S2,...",
+        help=(
+            "Comma-separated list of independent base_seeds for multi-seed"
+            " hold-out validation.  When set, supersedes --holdout-base-seed."
+            " Reduction across seeds: worst (most negative) drift, any overfit."
+            " Empty (default) disables multi-seed hold-out."
+            " Each seed must be non-zero, distinct, and differ from --base-seed."
         ),
     )
     run_p.add_argument(
@@ -311,39 +337,72 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _parse_seed_list(raw: str) -> tuple:
+    """Parse a comma-separated seed list (e.g. ``"1234,5678,9012"``).
+
+    Empty / blank → empty tuple.  Whitespace around entries is tolerated
+    so command-line callers can write ``"1234, 5678"`` without quoting
+    surprises.  Non-integer entries raise ``ValueError`` with the
+    offending token for ergonomic error messages.
+    """
+    s = (raw or "").strip()
+    if not s:
+        return ()
+    out = []
+    for piece in s.split(","):
+        token = piece.strip()
+        if not token:
+            continue
+        try:
+            out.append(int(token))
+        except ValueError as e:
+            raise ValueError(f"--holdout-base-seeds: invalid integer {token!r}") from e
+    return tuple(out)
+
+
 def _cmd_run(args: argparse.Namespace) -> int:
     from panobbgo.self_improve import LoopConfig, SelfImprover, default_catalog, default_structural_catalog
 
     catalog = default_structural_catalog() if args.structural else default_catalog()
-    cfg = LoopConfig(
-        iterations=args.iterations,
-        base_seed=args.base_seed,
-        mode=args.mode,
-        reps=args.reps,
-        budget=args.budget,
-        eps_accept=args.eps_accept,
-        eps_regress=args.eps_regress,
-        n_boot=args.n_boot,
-        confidence=args.confidence,
-        stat_seed=args.stat_seed,
-        mutation_seed=args.mutation_seed,
-        strategy_names=args.strategies,
-        ledger_path=args.ledger,
-        stop_sentinel_path=args.stop_sentinel,
-        timeout_per_run=args.timeout,
-        randomize=args.randomize,
-        guard_interval=args.guard_interval,
-        guard_eps_ladder=args.guard_eps_ladder,
-        guard_iteration_offset=args.guard_iteration_offset,
-        adaptive_sampling=args.adaptive_sampling,
-        adaptive_prior_alpha=args.adaptive_prior_alpha,
-        adaptive_prior_beta=args.adaptive_prior_beta,
-        adaptive_prime_from_ledger=args.adaptive_prime_from_ledger,
-        holdout_base_seed=args.holdout_base_seed,
-        holdout_iterations=args.holdout_iterations,
-        holdout_iteration_offset=args.holdout_iteration_offset,
-        holdout_eps_overfit=args.holdout_eps_overfit,
-    )
+    try:
+        holdout_seeds = _parse_seed_list(args.holdout_base_seeds)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    try:
+        cfg = LoopConfig(
+            iterations=args.iterations,
+            base_seed=args.base_seed,
+            mode=args.mode,
+            reps=args.reps,
+            budget=args.budget,
+            eps_accept=args.eps_accept,
+            eps_regress=args.eps_regress,
+            n_boot=args.n_boot,
+            confidence=args.confidence,
+            stat_seed=args.stat_seed,
+            mutation_seed=args.mutation_seed,
+            strategy_names=args.strategies,
+            ledger_path=args.ledger,
+            stop_sentinel_path=args.stop_sentinel,
+            timeout_per_run=args.timeout,
+            randomize=args.randomize,
+            guard_interval=args.guard_interval,
+            guard_eps_ladder=args.guard_eps_ladder,
+            guard_iteration_offset=args.guard_iteration_offset,
+            adaptive_sampling=args.adaptive_sampling,
+            adaptive_prior_alpha=args.adaptive_prior_alpha,
+            adaptive_prior_beta=args.adaptive_prior_beta,
+            adaptive_prime_from_ledger=args.adaptive_prime_from_ledger,
+            holdout_base_seed=args.holdout_base_seed,
+            holdout_base_seeds=holdout_seeds,
+            holdout_iterations=args.holdout_iterations,
+            holdout_iteration_offset=args.holdout_iteration_offset,
+            holdout_eps_overfit=args.holdout_eps_overfit,
+        )
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
     improver = SelfImprover(cfg, catalog=catalog)
     records, _, holdout_records = improver.run_full(verbose=not args.quiet)
 
@@ -360,14 +419,29 @@ def _cmd_run(args: argparse.Namespace) -> int:
                 cls, param, kind = s.rule_key
                 print(f"  {cls}.{param}[{kind}] -> {s.n_accepts}/{s.n_attempts} ({s.accept_rate:.0%})")
     if holdout_records:
-        ho = holdout_records[-1]
-        verdict = "OVERFIT" if ho.overfit else "OK"
-        print(
-            f"[self_improve] hold-out: {verdict}  drift={ho.drift:+.4f}  "
-            f"holdout_gap={ho.holdout_delta:+.4f}  training_gap={ho.training_delta:+.4f}  "
-            f"(base_seed={ho.holdout_base_seed}, n={ho.holdout_iterations})"
-        )
-        if ho.overfit and args.fail_on_overfit:
+        any_overfit = any(r.overfit for r in holdout_records)
+        # Worst-case generalisation: the most negative drift across seeds
+        # is the one a reviewer cares about — a positive aggregate hides
+        # a single bad seed.  Match the planning doc's `min` reduction.
+        worst = min(holdout_records, key=lambda r: r.drift)
+        if len(holdout_records) == 1:
+            ho = holdout_records[0]
+            verdict = "OVERFIT" if ho.overfit else "OK"
+            print(
+                f"[self_improve] hold-out: {verdict}  drift={ho.drift:+.4f}  "
+                f"holdout_gap={ho.holdout_delta:+.4f}  training_gap={ho.training_delta:+.4f}  "
+                f"(base_seed={ho.holdout_base_seed}, n={ho.holdout_iterations})"
+            )
+        else:
+            verdict = "OVERFIT" if any_overfit else "OK"
+            seeds = ",".join(str(r.holdout_base_seed) for r in holdout_records)
+            n_overfit = sum(1 for r in holdout_records if r.overfit)
+            print(
+                f"[self_improve] hold-out aggregate: {verdict}  worst_drift={worst.drift:+.4f}  "
+                f"overfit={n_overfit}/{len(holdout_records)}  worst_seed={worst.holdout_base_seed}  "
+                f"(seeds=[{seeds}], n={worst.holdout_iterations})"
+            )
+        if any_overfit and args.fail_on_overfit:
             return 3
     return 0
 
@@ -429,6 +503,10 @@ def _cmd_summary(args: argparse.Namespace) -> int:
                 f"new top iter={r.get('rolled_back_to_iteration')}"
             )
     if holdout_records:
+        # Multi-seed hold-out lands as multiple records back-to-back per
+        # loop run (one per seed).  Reduce to the worst (most negative)
+        # drift so the summary surfaces the failure mode a single-seed
+        # check would have missed.
         print("Hold-out validation:")
         for r in holdout_records:
             verdict = "OVERFIT" if r.get("overfit") else "OK"
@@ -438,6 +516,14 @@ def _cmd_summary(args: argparse.Namespace) -> int:
                 f"training_gap={r.get('training_delta'):+.4f}  "
                 f"top_iter={r.get('top_iteration')}  "
                 f"(base_seed={r.get('holdout_base_seed')}, n={r.get('holdout_iterations')})"
+            )
+        if len(holdout_records) > 1:
+            worst = min(holdout_records, key=lambda r: float(r.get("drift", 0.0)))
+            n_overfit = sum(1 for r in holdout_records if r.get("overfit"))
+            agg = "OVERFIT" if n_overfit else "OK"
+            print(
+                f"  --> aggregate: {agg}  worst_drift={float(worst.get('drift', 0.0)):+.4f}  "
+                f"overfit={n_overfit}/{len(holdout_records)}  worst_seed={worst.get('holdout_base_seed')}"
             )
     return 0
 

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -2529,3 +2529,315 @@ class TestLoopHoldoutRecord:
         parsed = json.loads(s)
         assert parsed["record_type"] == "holdout"
         assert parsed["holdout_base_seed"] == 99
+
+
+# ===========================================================================
+# Multi-seed hold-out (planning/SELF_IMPROVEMENT_LOOP.md §13 follow-up)
+# ===========================================================================
+
+
+class TestLoopConfigMultiSeedHoldout:
+    """Validation of the list-typed ``holdout_base_seeds`` knob.
+
+    The single-seed scalar landed in 2026-05-08; the list version turns
+    a single drift draw into a worst-case estimate over multiple
+    independent SHA-256 streams.  Validation rules mirror the scalar
+    case (no collision with base_seed) plus list-only constraints
+    (no zero entries, no duplicates).
+    """
+
+    def test_default_is_empty_tuple(self):
+        cfg = LoopConfig()
+        assert cfg.holdout_base_seeds == ()
+
+    def test_accepts_list_and_normalizes_to_tuple(self):
+        cfg = LoopConfig(holdout_base_seeds=[1, 2, 3])
+        # The dataclass stores tuples for hashability and equality stability.
+        assert isinstance(cfg.holdout_base_seeds, tuple)
+        assert cfg.holdout_base_seeds == (1, 2, 3)
+
+    def test_rejects_zero_entry(self):
+        # 0 is the disable sentinel — accepting it here would silently
+        # produce a no-op call against the *training* base seed family.
+        with pytest.raises(ValueError, match="non-zero"):
+            LoopConfig(holdout_base_seeds=(1234, 0, 5678))
+
+    def test_rejects_collision_with_base_seed(self):
+        with pytest.raises(ValueError, match="must differ from base_seed"):
+            LoopConfig(base_seed=42, holdout_base_seeds=(99, 42, 77))
+
+    def test_rejects_duplicates(self):
+        with pytest.raises(ValueError, match="distinct"):
+            LoopConfig(holdout_base_seeds=(1234, 5678, 1234))
+
+    def test_resolved_seeds_prefers_list_over_scalar(self):
+        """When both knobs are set, the list takes precedence."""
+        cfg = LoopConfig(holdout_base_seed=99, holdout_base_seeds=(1234, 5678))
+        assert cfg.resolved_holdout_seeds() == (1234, 5678)
+
+    def test_resolved_seeds_falls_back_to_scalar(self):
+        """Scalar promoted to a 1-tuple for the multi-seed code path."""
+        cfg = LoopConfig(holdout_base_seed=99)
+        assert cfg.resolved_holdout_seeds() == (99,)
+
+    def test_resolved_seeds_empty_when_both_unset(self):
+        cfg = LoopConfig()
+        assert cfg.resolved_holdout_seeds() == ()
+
+    def test_holdout_harness_config_accepts_explicit_seed(self):
+        """The explicit ``base_seed`` argument overrides ``holdout_base_seed``.
+
+        This is the wiring the multi-seed loop relies on — without it,
+        every per-seed iteration would still measure against the
+        scalar attribute.
+        """
+        cfg = LoopConfig(base_seed=42, holdout_base_seed=99)
+        hc = cfg.holdout_harness_config([], iteration_id=3, base_seed=5678)
+        assert hc.seed == 5678
+        assert hc.randomize_iteration == 3
+
+    def test_holdout_harness_config_defaults_to_scalar(self):
+        """Omitting ``base_seed`` keeps the single-seed back-compat path."""
+        cfg = LoopConfig(base_seed=42, holdout_base_seed=99)
+        hc = cfg.holdout_harness_config([], iteration_id=3)
+        assert hc.seed == 99
+
+
+class TestSelfImproverMultiSeedHoldout:
+    """End-to-end behaviour with ``holdout_base_seeds`` set."""
+
+    def test_writes_one_record_per_seed(self, tmp_path):
+        """Each seed produces its own LoopHoldoutRecord, in order."""
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=True,
+            base_seed=42,
+            holdout_base_seeds=(99, 101, 103),
+            holdout_iterations=2,
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.4)
+        _, _, holdout_records = si.run_full()
+        assert len(holdout_records) == 3
+        # Records preserve seed order so a ledger audit lines up with
+        # the configured list.
+        assert [r.holdout_base_seed for r in holdout_records] == [99, 101, 103]
+
+    def test_uses_each_seed_for_measurement(self, tmp_path):
+        """Hold-out measurements must use the per-seed base_seed.
+
+        The call log proves we actually drew from the configured
+        SHA-256 streams rather than reusing the scalar or the
+        training seed.
+        """
+        call_log: List[Dict[str, Any]] = []
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=True,
+            base_seed=42,
+            holdout_base_seeds=(1234, 5678),
+            holdout_iterations=2,
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.5, call_log=call_log)
+        si.run_full()
+
+        seeds_seen = {c["seed"] for c in call_log}
+        # 42 = training, 1234/5678 = hold-out streams.  No leakage of
+        # 99 or 0 anywhere.
+        assert 42 in seeds_seen
+        assert 1234 in seeds_seen
+        assert 5678 in seeds_seen
+        assert 0 not in seeds_seen
+        assert 99 not in seeds_seen
+
+    def test_overfit_on_one_seed_only(self, tmp_path):
+        """Per-record overfit is computed independently per seed.
+
+        Setup: seed 99 collapses (drift = -0.5), seed 7777 holds
+        (drift ≈ 0).  We expect record[0].overfit == True and
+        record[1].overfit == False — the aggregation across seeds is
+        the CLI's job, not the loop's.
+        """
+        counter = {"n": 0}
+
+        def score_fn(config: HarnessConfig) -> float:
+            if config.seed == 99:
+                return 0.3  # collapsed gap on seed 99
+            if config.seed == 7777:
+                # Hold-out preserves the gap.  Alternate seed/top eval.
+                ho = counter.get("ho2", 0)
+                counter["ho2"] = ho + 1
+                return 0.3 if ho % 2 == 0 else 0.78
+            n = counter["n"]
+            counter["n"] += 1
+            # Training alternation: baseline (0.3) / candidate (0.8).
+            return 0.3 if n % 2 == 0 else 0.8
+
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=True,
+            base_seed=42,
+            holdout_base_seeds=(99, 7777),
+            holdout_iterations=4,
+            holdout_eps_overfit=0.05,
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(score_fn)
+        iter_records, _, holdout_records = si.run_full()
+        assert iter_records[0].accepted is True
+        assert len(holdout_records) == 2
+        # Seed 99: collapsed -> overfit; seed 7777: held -> not overfit.
+        assert holdout_records[0].holdout_base_seed == 99
+        assert holdout_records[0].overfit is True
+        assert holdout_records[1].holdout_base_seed == 7777
+        assert holdout_records[1].overfit is False
+
+    def test_list_takes_precedence_over_scalar(self, tmp_path):
+        """If both scalar and list are set, only the list seeds are used."""
+        call_log: List[Dict[str, Any]] = []
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=True,
+            base_seed=42,
+            holdout_base_seed=99,
+            holdout_base_seeds=(1234, 5678),
+            holdout_iterations=1,
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.5, call_log=call_log)
+        si.run_full()
+        seeds_seen = {c["seed"] for c in call_log}
+        # 99 (the scalar) must NOT appear when the list is set.
+        assert 99 not in seeds_seen
+        assert 1234 in seeds_seen
+        assert 5678 in seeds_seen
+
+    def test_writes_all_records_to_ledger(self, tmp_path):
+        """All per-seed records land in the JSONL ledger with type=holdout."""
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=True,
+            base_seed=42,
+            holdout_base_seeds=(11, 22, 33),
+            holdout_iterations=1,
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.4)
+        si.run_full()
+
+        records = load_ledger(cfg.ledger_path)
+        holdout_rows = [r for r in records if r.get("record_type") == "holdout"]
+        assert len(holdout_rows) == 3
+        assert [r["holdout_base_seed"] for r in holdout_rows] == [11, 22, 33]
+
+    def test_scalar_path_unaffected(self, tmp_path):
+        """Existing scalar callers see exactly one record (back-compat)."""
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=True,
+            base_seed=42,
+            holdout_base_seed=99,  # scalar only
+            holdout_iterations=2,
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.4)
+        _, _, holdout_records = si.run_full()
+        assert len(holdout_records) == 1
+        assert holdout_records[0].holdout_base_seed == 99
+
+    def test_disabled_when_only_zero_scalar(self, tmp_path):
+        """``holdout_base_seed=0`` + empty list = hold-out disabled."""
+        cfg = LoopConfig(
+            iterations=1,
+            n_boot=50,
+            ledger_path=str(tmp_path / "ledger.jsonl"),
+            stop_sentinel_path="",
+            randomize=True,
+            base_seed=42,
+            # both knobs at default => disabled
+            holdout_iterations=2,
+        )
+        si = SelfImprover(cfg, catalog=_accept_radius_catalog(), seed_strategies=_make_specs())
+        si._harness_factory = _make_factory(lambda c: 0.4)
+        _, _, holdout_records = si.run_full()
+        assert holdout_records == []
+
+
+class TestCliSeedListParser:
+    """Tests for ``scripts/self_improve.py:_parse_seed_list``.
+
+    The parser is the only CLI-side surface the user touches for
+    multi-seed hold-out; the loop driver receives a tuple either way.
+    """
+
+    @staticmethod
+    def _parser():
+        import sys
+
+        sys.path.insert(0, str(pathlib.Path(__file__).parents[1] / "scripts"))
+        try:
+            import self_improve as cli  # type: ignore
+
+            return cli._parse_seed_list
+        finally:
+            # Don't leave the import path polluted for downstream tests.
+            sys.path = [p for p in sys.path if not p.endswith("/scripts")]
+
+    def test_empty_string_returns_empty_tuple(self):
+        parse = self._parser()
+        assert parse("") == ()
+
+    def test_whitespace_only_returns_empty_tuple(self):
+        parse = self._parser()
+        assert parse("   ") == ()
+
+    def test_single_int(self):
+        parse = self._parser()
+        assert parse("1234") == (1234,)
+
+    def test_multiple_ints(self):
+        parse = self._parser()
+        assert parse("1,2,3") == (1, 2, 3)
+
+    def test_tolerates_whitespace_around_entries(self):
+        # `--holdout-base-seeds "1234, 5678"` should work without
+        # forcing the user to remember to omit the space.
+        parse = self._parser()
+        assert parse("1234, 5678 , 9012") == (1234, 5678, 9012)
+
+    def test_negative_int_accepted(self):
+        # The validator on LoopConfig rejects 0 and duplicates; the
+        # parser itself stays tolerant of negative ints so the loop
+        # config gets to emit a clearer error.
+        parse = self._parser()
+        assert parse("-1,2") == (-1, 2)
+
+    def test_rejects_non_integer(self):
+        parse = self._parser()
+        with pytest.raises(ValueError, match="invalid integer"):
+            parse("1,foo,3")
+
+    def test_skips_empty_entries_from_trailing_comma(self):
+        parse = self._parser()
+        # Trailing commas are common in copy/paste; quietly tolerate them.
+        assert parse("1,2,3,") == (1, 2, 3)
+        assert parse(",1,2") == (1, 2)


### PR DESCRIPTION
## Summary

Extends the single-seed hold-out shipped 2026-05-08 with a list-typed `LoopConfig.holdout_base_seeds` knob and a `--holdout-base-seeds 1234,5678,9012` CLI flag. At the end of every loop run, one `LoopHoldoutRecord` is written per seed in the list and the CLI aggregates the verdicts with worst-case drift (`min`) and any-overfit (`any`) semantics — strictly more conservative than reducing the entire generalisation question to one independent SHA-256 draw.

Closes the *Multi-seed hold-out for robust drift estimation* follow-up in `planning/SELF_IMPROVEMENT_LOOP.md`.

### Why this matters

The single-seed hold-out catches overfit to the training base_seed family by checking the ladder against one independent SHA-256 stream. When a ladder overfits in a subtle way — for example, exploiting a quirk that happens to repeat across the chosen hold-out seed — that one draw can miss it. The latest production ledger shows `drift=-0.0074` (well within the default `eps_overfit=0.05`, but on a single draw it's hard to know whether `-0.0074` is the typical drift or the lucky tail of a larger one). Aggregating over several seeds gives a worst-case estimate at a cost that stays small relative to the loop's training budget.

### What changed

- **`LoopConfig.holdout_base_seeds: Tuple[int, ...]`** (default `()`). Validation rejects `0` entries (the disable sentinel), collision with `base_seed`, and duplicates with distinct error messages. Lists normalized to tuples for hashability.
- **`LoopConfig.resolved_holdout_seeds()`** collapses both knobs onto one tuple: list when non-empty, else scalar promoted to a 1-tuple, else empty. The multi-seed loop driver uses this single branch.
- **`LoopConfig.holdout_harness_config(..., base_seed=None)`** gains an optional override so the loop can drive `HarnessConfig.seed` per call.
- **`SelfImprover._run_holdout(ladder, base_seed, verbose)`** takes the seed as a parameter; `_run_internal` iterates over the resolved tuple and writes one `LoopHoldoutRecord` per seed. `record_type='holdout'` unchanged.
- **CLI:** `--holdout-base-seeds 1234,5678,9012`. Comma-separated list, tolerates whitespace and trailing commas, rejects non-integer tokens with a clear CLI error. End-of-run summary line and `summary` subcommand both report the aggregated verdict.

### Tests

25 new tests in `tests/test_self_improve.py` (total **147**, up from 122):

- `TestLoopConfigMultiSeedHoldout` (10): defaults, list/tuple normalization, rejection paths (zero / collision / duplicates), `resolved_holdout_seeds()` precedence rules, `holdout_harness_config()` explicit-seed override.
- `TestSelfImproverMultiSeedHoldout` (7): one record per seed in configured order, per-seed harness seeds reach the factory, overfit flagged independently per seed, list-wins-over-scalar precedence, ledger writes all records, scalar back-compat path, disable when both knobs unset.
- `TestCliSeedListParser` (8): empty / whitespace / single / multiple / whitespace-tolerant / negative-accepted / non-integer-rejected / trailing-comma-skipped paths.

All 321 tests in `test_self_improve.py` + `test_harness*` pass locally; pyright (`panobbgo/`), ruff format, and ruff check all clean.

### Backwards compatibility

Strictly safe. The default empty tuple keeps every existing CLI invocation byte-identical; ledger consumers see no schema change. When both `holdout_base_seed` (scalar) and `holdout_base_seeds` (list) are set, the list takes precedence (the explicit "do exactly this" override) and the scalar is silently ignored.

### Documentation updated

- `planning/SELF_IMPROVEMENT_LOOP.md`: §2 missing-pieces list, Phase 6 checklist, new §13 entry, follow-up promoted from "open" to "shipped".
- `doc/source/guide_benchmarking.rst`: new "Multi-seed hold-out" subsection with aggregation rule, validation rules, CLI example, programmatic example.
- `doc/source/guide.rst`: quick-nav entry mentions multi-seed hold-out.
- `AGENTS.md`: self-improvement loop subsection lists the multi-seed feature with a run-the-loop bash example.
- `TODO.md`: detailed shipping note.

## Test plan

- [x] `uv run pytest tests/test_self_improve.py` — 147 passed
- [x] `uv run pytest tests/test_self_improve.py tests/test_harness*` — 321 passed
- [x] `uv run pyright panobbgo` — 0 errors, 0 warnings
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ruff check panobbgo/self_improve.py tests/test_self_improve.py scripts/self_improve.py` — clean
- [x] `uv run python scripts/self_improve.py run --help` shows `--holdout-base-seeds`
- [x] CLI error path: `--holdout-base-seeds "1234,1234"` exits non-zero with clear error
- [x] CLI error path: `--holdout-base-seeds "foo,2"` exits non-zero with clear error
- [ ] Full CI green

https://claude.ai/code/session_01XpS4WMTaw22CScXVpep6Rz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpS4WMTaw22CScXVpep6Rz)_