### PR TITLE
test: always-on --durations + opt-in pytest-xdist parallelism

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,20 @@ jobs:
           uv sync
 
       - name: Run pytest
+        # `--durations=25` (from pyproject `addopts`) prints the slowest 25
+        # tests so every CI run records where the ~20 min wall-clock goes —
+        # the suite is dominated by latency-bound `.start()` integration
+        # tests (threaded event loop, not CPU).
+        #
+        # NOTE: the suite is NOT yet run in parallel here. `pytest-xdist` is
+        # installed and `-n auto --dist loadscope` works locally with a large
+        # wall-clock win, but two issues must be fixed first (see
+        # planning/TEST_PERFORMANCE.md): (1) one worker hangs in teardown at
+        # end-of-run (a non-daemon background thread left by a strategy/dask
+        # test), which would trip the 25 min job timeout; (2) a couple of
+        # timing-sensitive `@pytest.mark.flaky` tests fail under heavy
+        # CPU contention because `pytest-retry` is not installed in the
+        # `--extra dev` set CI uses, so the flaky markers are currently no-ops.
         run: |
           uv run pytest -v --cov=panobbgo --cov-report=xml --cov-report=term
           uv run coverage report --format=markdown >> $GITHUB_STEP_SUMMARY

--- a/planning/TEST_PERFORMANCE.md
+++ b/planning/TEST_PERFORMANCE.md
@@ -1,0 +1,86 @@
+# Test-suite performance notes
+
+The `test` CI job is the long pole: ~20–22 min wall-clock (e.g. PR #233 ran
+22m10s), versus seconds for `lint` / `format` / `typecheck` / `build` /
+`docs`. This note records *why* and what we measured, so future work has data
+to start from.
+
+## Why it is slow (not what you'd guess)
+
+The cost is **not** CPU and **not** a few pathological tests doing huge
+computations. The two `max_eval = 200000` references in the suite
+(`test_core.py`, `test_strategies.py`) are **config-validation** tests that
+only check the "unreasonably high" guard fires — they never run an
+optimization.
+
+The real cost is **breadth**: ~79 tests each call `strategy.start()`, which
+spins up the full asynchronous optimizer (event bus + threaded/dask worker
+pool) and drives it to a small budget. These are **latency / event-loop
+bound**, not CPU bound — a local profile of the slow CMA-ES integration
+cluster showed ~19% CPU while wall-clock ticked up (the process spends most of
+its time waiting on the threaded event loop, fixed `time.sleep`s, and dask
+`LocalCluster` spin-up/teardown). Coverage instrumentation (`--cov`) adds
+more.
+
+A symptom of the buffered, serial run: CI output appears to "stick" after
+`test_heuristic_cmaes.py::test_ipop_cmaes_integration_rastrigin` and then jump
+ahead — that is `-v` output buffering plus the genuinely slow CMA-ES
+IPOP/BIPOP `.start()` restart tests, not a true hang.
+
+## Timing data
+
+`--durations=25` is now always on (pyproject `addopts`), so every run — local
+and CI — prints the 25 slowest tests. Read the CI `test` job log to see the
+current hot list. The heaviest are the `.start()` integration tests
+(CMA-ES IPOP/BIPOP restarts, the constraint integration suites, the
+self-improve structural end-to-end tests).
+
+## Parallelism: measured, promising, not yet shipped to CI
+
+`pytest-xdist` is installed. Locally:
+
+```
+uv run pytest -n auto --dist loadscope
+```
+
+runs the suite across all cores with a large wall-clock win — because the
+work is latency-bound, it parallelises near-linearly. `--dist loadscope`
+keeps each test *module* on one worker, which preserves module-level fixtures
+and avoids cross-worker file collisions for free. (`pytest-benchmark`
+auto-disables under xdist; no benchmark tests use the `benchmark` fixture in
+the main suite, so that is a non-issue.)
+
+It is **not yet enabled in CI** because two issues surface under full
+parallel load and must be fixed first:
+
+1. **End-of-run teardown hang.** With `-n auto`, the run reaches ~99% (all
+   tests effectively done) and then one worker hangs in shutdown — almost
+   certainly a non-daemon background thread left running by a strategy/dask
+   test (xdist worker processes must exit cleanly; a serial run does not
+   because the interpreter exits regardless). A 600 s local run was killed by
+   timeout at this point. In CI this would trip the 25 min `test` job timeout.
+   Fix: find the offending module (bisect modules under xdist) and ensure its
+   strategies/clusters are torn down (the `real_strategy` conftest fixture
+   already calls `_cleanup()`; some tests construct strategies without it).
+
+2. **Flaky tests under CPU contention.** `tests/test_harness.py::
+   test_statistical_compare` failed once in a full 16-worker run but passes
+   reliably in isolation (`pytest -n 2 tests/test_harness.py` → 62/62). A
+   handful of `@pytest.mark.flaky`-marked, timing-sensitive tests can tip over
+   when 16 workers contend for the CPU. Note `@pytest.mark.flaky` is a
+   **no-op in CI today**: it is powered by `pytest-retry`, which lives only in
+   `[dependency-groups].dev`, not in the `[project.optional-dependencies].dev`
+   set that CI installs via `uv sync --extra dev`. Adding `pytest-retry` to
+   the `--extra dev` set (and/or a global `--retries`) would make the existing
+   markers effective and absorb contention-induced flakiness.
+
+Once (1) and (2) are addressed, switch the CI `test` step to
+`uv run pytest -n auto --dist loadscope --cov=...` for an expected ~3–4×
+wall-clock reduction.
+
+## Parallel-safety hygiene already done
+
+The two SQLite storage fixtures (`tests/test_storage.py`,
+`tests/test_storage_integration.py`) now write to a per-test `tmp_path`
+instead of a fixed filename in the CWD, so parallel workers cannot collide on
+them.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ benchmark = [
 dev = [
     "pytest>=9.0.3",
     "pytest-cov>=5.0",
+    "pytest-xdist>=3.6",
     "pytest-benchmark>=4.0",
     "flake8>=7.3",
     "ruff>=0.14.13",
@@ -67,6 +68,15 @@ include = ["panobbgo*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# `--durations` surfaces the slowest tests on every run so we keep timing
+# data to spot long-running integration drivers (e.g. the CMA-ES IPOP/BIPOP
+# `.start()` tests, which are wall-clock/event-loop bound, not CPU bound).
+# Parallelism is opt-in via the CLI: `pytest-xdist` is installed, so
+# `uv run pytest -n auto --dist loadscope` parallelises the suite locally
+# for a large wall-clock win. It is not yet wired into CI — see
+# planning/TEST_PERFORMANCE.md for the two blockers (end-of-run teardown
+# hang + flaky tests under contention). A plain `pytest` stays serial.
+addopts = "--durations=25 -ra"
 
 [tool.ruff]
 line-length = 120
@@ -93,6 +103,7 @@ dev = [
     "pyright>=1.1.407",
     "pytest-benchmark>=5.2.3",
     "pytest-cov>=7.0.0",
+    "pytest-xdist>=3.6",
     "pytest-retry>=1.7.0",
     "pytest-benchmark>=4.0",
     "shibuya>=2026.1.9",

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -7,8 +7,10 @@ from panobbgo.lib import Result, Point
 
 
 @pytest.fixture
-def storage_uri():
-    uri = "test_storage.db"
+def storage_uri(tmp_path):
+    # Per-test temp dir keeps parallel workers (pytest-xdist) from colliding
+    # on a shared on-disk filename.
+    uri = str(tmp_path / "test_storage.db")
     yield uri
     if os.path.exists(uri):
         os.unlink(uri)

--- a/tests/test_storage_integration.py
+++ b/tests/test_storage_integration.py
@@ -8,8 +8,10 @@ from panobbgo.heuristics import Random
 
 
 @pytest.fixture
-def storage_uri():
-    uri = "test_integration.db"
+def storage_uri(tmp_path):
+    # Per-test temp dir keeps parallel workers (pytest-xdist) from colliding
+    # on a shared on-disk filename.
+    uri = str(tmp_path / "test_integration.db")
     yield uri
     if os.path.exists(uri):
         os.unlink(uri)

--- a/uv.lock
+++ b/uv.lock
@@ -409,6 +409,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "flake8"
 version = "7.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1175,6 +1184,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "shibuya" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -1189,6 +1199,7 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pytest-retry" },
+    { name = "pytest-xdist" },
     { name = "shibuya" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -1211,6 +1222,7 @@ requires-dist = [
     { name = "pytest-benchmark", specifier = ">=5.2.3" },
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rich", specifier = ">=14.2.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.13" },
@@ -1231,6 +1243,7 @@ dev = [
     { name = "pytest-benchmark", specifier = ">=5.2.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-retry", specifier = ">=1.7.0" },
+    { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "shibuya", specifier = ">=2026.1.9" },
     { name = "sphinx", specifier = ">=8.1.3" },
 ]
@@ -1525,6 +1538,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c5/5b/607b017994cca28de3a1ad22a3eee8418e5d428dcd8ec25b26b18e995a73/pytest_retry-1.7.0.tar.gz", hash = "sha256:f8d52339f01e949df47c11ba9ee8d5b362f5824dff580d3870ec9ae0057df80f", size = 19977, upload-time = "2025-01-19T01:56:13.115Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/ff/3266c8a73b9b93c4b14160a7e2b31d1e1088e28ed29f4c2d93ae34093bfd/pytest_retry-1.7.0-py3-none-any.whl", hash = "sha256:a2dac85b79a4e2375943f1429479c65beb6c69553e7dae6b8332be47a60954f4", size = 13775, upload-time = "2025-01-19T01:56:11.199Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Motivation

The `test` CI job is the long pole — ~20–22 min wall-clock (PR #233 ran 22m10s) versus seconds for `lint` / `format` / `typecheck` / `build` / `docs`. This PR adds **timing visibility** so we always have data on where that time goes, plus makes **parallelism available** for a large local speedup.

## What I found

The slowness is **breadth, not a few heavy tests**:
- The two `max_eval = 200000` references are *config-validation* tests — they never run an optimization.
- ~79 tests each call `strategy.start()`, spinning up the full async optimizer (event bus + threaded/dask workers). These are **latency / event-loop bound, not CPU bound** (profiled ~19% CPU while wall-clock ticked up), so they parallelise near-linearly.
- The CI "stuck after `test_ipop_cmaes_integration_rastrigin`" effect is `-v` output buffering + the genuinely slow CMA-ES IPOP/BIPOP restart tests.

## Changes

- **Always-on `--durations=25 -ra`** (pyproject `addopts`) → every run, local and CI, prints the 25 slowest tests. Primary deliverable, zero risk.
- **`pytest-xdist`** added to both dev dependency sets. `uv run pytest -n auto --dist loadscope` parallelises locally with a big wall-clock win.
- **Storage fixtures → `tmp_path`** (`test_storage.py`, `test_storage_integration.py`) so parallel workers don't collide on a fixed CWD filename.
- **`planning/TEST_PERFORMANCE.md`** documents the measurements + the two blockers before CI can go parallel.

## Why CI stays serial for now

Under full `-n auto` load two issues surface (documented for follow-up):
1. **End-of-run teardown hang** — one worker hangs in shutdown at ~99% (a non-daemon thread left by a strategy/dask test); would trip the 25 min job timeout.
2. **Flaky-under-contention** — `test_harness.py::test_statistical_compare` failed once in a 16-worker run but passes 62/62 in isolation. `@pytest.mark.flaky` is a no-op in CI today because `pytest-retry` is only in `[dependency-groups].dev`, not the `--extra dev` set CI installs.

Once those are fixed, switching the CI step to `-n auto --dist loadscope` should give ~3–4× wall-clock reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)