### PR TITLE
refactor: extract Dask out of core.py; raise coverage of two heuristics

### DIFF
--- a/doc/source/core.rst
+++ b/doc/source/core.rst
@@ -14,3 +14,14 @@ The core module provides the fundamental building blocks:
    :undoc-members:
    :show-inheritance:
 
+
+Dask Evaluation Backend
+-----------------------
+
+Optional distributed-evaluation backend (``evaluation_method = "dask"``),
+imported lazily so the core carries no Dask dependency. Install the
+``dask`` extra to use it.
+
+.. automodule:: panobbgo.dask_evaluation
+   :members:
+   :undoc-members:

--- a/doc/source/guide_architecture.rst
+++ b/doc/source/guide_architecture.rst
@@ -657,6 +657,9 @@ Function evaluations can run in parallel using different engines:
 
 - **Threaded (Default)**: Evaluations run in a local thread pool. Suitable for lightweight functions or when running on a single machine.
 - **Dask Distributed**: Connects to a Dask cluster for large-scale distributed evaluation.
+  All Dask-specific code lives in :mod:`panobbgo.dask_evaluation` and is imported
+  lazily — install the optional extra (``pip install panobbgo[dask]`` or
+  ``uv sync --extra dask``) to use it.
 
 **Dask setup (optional):**
 

--- a/doc/source/guide_usage.rst
+++ b/doc/source/guide_usage.rst
@@ -9,13 +9,13 @@ Installation
 Requirements
 ~~~~~~~~~~~~
 
-- Python ≥ 3.8
+- Python ≥ 3.11
 - NumPy ≥ 2.0
 - SciPy ≥ 1.16
 - matplotlib ≥ 3.0
 - pandas ≥ 2.0
 - statsmodels ≥ 0.14
-- Dask ≥ 2023.0
+- Dask ≥ 2026.1 (optional — only for ``evaluation: method: dask``; install via the ``dask`` extra)
 
 Using UV (Recommended)
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -52,10 +52,12 @@ By default, Panobbgo uses local threads for evaluation. This requires no additio
 
 For large-scale distributed optimization, you can use a Dask cluster:
 
-1. **Install Dask**:
+1. **Install the dask extra** (Dask is not a core dependency; the backend
+   lives in :mod:`panobbgo.dask_evaluation` and is imported lazily):
+
    .. code-block:: bash
 
-      pip install dask[distributed]
+      pip install "panobbgo[dask]"     # or: uv sync --extra dask
 
 2. **Start Cluster**:
    .. code-block:: bash

--- a/panobbgo/core.py
+++ b/panobbgo/core.py
@@ -1013,6 +1013,13 @@ class StrategyBase:
     # constant reference id for sending the evaluation code to workers
     PROBLEM_KEY = "problem"
 
+    # Dask backend state — assigned lazily by panobbgo.dask_evaluation when
+    # evaluation_method == "dask" (and directly by some tests); declared here
+    # for static checkers only.
+    _client: Any
+    _cluster: Any
+    _problem_future: Any
+
     def __init__(self, problem, parse_args=False, testing_mode=False, **kwargs):
         """
 
@@ -1048,7 +1055,7 @@ class StrategyBase:
         pd.set_option("display.precision", 2)  # default 7
 
         # statistics
-        self.show_last = 0  # for printing the info line in _add_tasks()
+        self.show_last = 0.0  # for throttling the info line (see dask_evaluation._add_tasks)
         self._last_status_update = 0  # for throttling _update_progress_status
         self.time_start = time_module.time()
         self.tasks_walltimes = {}
@@ -1376,43 +1383,17 @@ class StrategyBase:
         - 'dask': Distributed evaluation for heavy workloads
         """
         if self.config.evaluation_method == "dask":
-            self._setup_dask_cluster(problem)
+            # Dask is fully isolated in its own module and imported lazily —
+            # see panobbgo/dask_evaluation.py
+            from . import dask_evaluation
+
+            dask_evaluation.setup_cluster(self, problem)
         elif self.config.evaluation_method == "processes":
             self._setup_process_evaluation(problem)
         elif self.config.evaluation_method == "threaded":
             self._setup_threaded_evaluation(problem)
         else:
             raise ValueError(f"Unknown evaluation method: {self.config.evaluation_method}")
-
-    def _setup_dask_cluster(self, problem):
-        """
-        Set up a Dask cluster based on configuration.
-        Supports both local and remote clusters.
-        """
-        from dask.distributed import Client, LocalCluster
-
-        if self.config.dask_cluster_type == "local":
-            # Create a local cluster
-            self.logger.info("Setting up local Dask cluster with %d workers" % self.config.dask_n_workers)
-            self._cluster = LocalCluster(
-                n_workers=int(self.config.dask_n_workers),
-                threads_per_worker=int(self.config.dask_threads_per_worker),
-                memory_limit=str(self.config.dask_memory_limit),
-                dashboard_address=str(self.config.dask_dashboard_address),
-                silence_logs=False,
-            )
-            self._client = Client(self._cluster)
-        else:
-            # Connect to remote cluster
-            self.logger.info("Connecting to remote Dask cluster at %s" % self.config.dask_scheduler_address)
-            self._client = Client(self.config.dask_scheduler_address)
-
-        # Scatter the problem to all workers
-        self._problem_future = self._client.scatter(problem, broadcast=True)
-
-        self.logger.info("Dask cluster ready with %d workers" % len(self._client.scheduler_info()["workers"]))
-        if self.config.dask_cluster_type == "local":
-            self.logger.info("Dashboard available at: http://localhost%s" % self.config.dask_dashboard_address)
 
     def _setup_process_evaluation(self, problem):
         """
@@ -1483,23 +1464,9 @@ class StrategyBase:
         Returns a mock object with attributes needed by strategies.
         """
         if self.config.evaluation_method == "dask":
+            from . import dask_evaluation
 
-            class DaskEvaluatorsMock:
-                def __init__(self, strategy):
-                    self.strategy = strategy
-
-                @property
-                def outstanding(self):
-                    # Return list of pending task keys
-                    return list(self.strategy.pending.keys())
-
-                def __len__(self):
-                    # Return number of Dask workers
-                    if hasattr(self.strategy, "_client"):
-                        return len(self.strategy._client.scheduler_info()["workers"])
-                    return 0
-
-            return DaskEvaluatorsMock(self)
+            return dask_evaluation.DaskEvaluators(self)
         else:  # process or threaded evaluation
 
             class DirectEvaluatorsMock:
@@ -1550,7 +1517,9 @@ class StrategyBase:
             self._update_progress_status()
 
             if self.config.evaluation_method == "dask":
-                self._run_dask_evaluation(points)
+                from . import dask_evaluation
+
+                self.results += dask_evaluation.run_evaluation(self, points)
             elif self.config.evaluation_method == "processes":
                 self._run_process_evaluation(points)
             elif self.config.evaluation_method == "threaded":
@@ -1605,45 +1574,6 @@ class StrategyBase:
         # Final forced update to ensure UI shows 100% or final results
         self._update_progress_status(force=True)
         self._cleanup()
-
-    def _run_dask_evaluation(self, points):
-        """Run evaluation using Dask distributed computing."""
-
-        # Helper function to evaluate a point using the problem
-        def evaluate_point(problem, point):
-            """Evaluate a single point using the problem instance"""
-            return problem(point)
-
-        # distribute work using Dask futures
-        # Submit each point as a separate task
-        new_futures = []
-        for point in points:
-            future = self._client.submit(
-                evaluate_point,
-                self._problem_future,
-                point,
-                pure=False,  # Function may have side effects
-            )
-            new_futures.append(future)
-
-        # and don't forget, this updates the statistics
-        self._add_tasks(new_futures)
-
-        # collect new results for each finished task, hand them over to result DB
-        new_results = []
-        for future_id in self.new_finished:
-            future = self.pending.pop(future_id, None)
-            if future is not None:
-                try:
-                    result = future.result()
-                    if isinstance(result, list):
-                        new_results.extend(result)
-                    else:
-                        new_results.append(result)
-                except Exception as e:
-                    self.logger.error("Task failed with error: %s" % e)
-
-        self.results += new_results
 
     def _run_process_evaluation(self, points):
         """Run evaluation using subprocess calls."""
@@ -1924,18 +1854,10 @@ with open('{result_file.name}', 'wb') as f:
         self._end = time_module.time()
 
         if self.config.evaluation_method == "dask":
-            # Cancel any outstanding Dask futures
-            for future in list(self.pending.values()):
-                try:
-                    future.cancel()
-                except:
-                    pass
+            from . import dask_evaluation
 
-            # Close Dask client and cluster
-            if hasattr(self, "_client"):
-                self._client.close()
-            if hasattr(self, "_cluster"):
-                self._cluster.close()
+            # Cancel outstanding futures, close client + cluster
+            dask_evaluation.close(self)
         elif self.config.evaluation_method == "processes":
             # Clean up problem file for process evaluation
             if hasattr(self, "_problem_file"):
@@ -1978,39 +1900,6 @@ with open('{result_file.name}', 'wb') as f:
         if stop_on_conv:
             self.logger.info(f"Convergence detected: {reason}. Stopping strategy.")
             self._stop_requested = True
-
-    def _add_tasks(self, new_futures):
-        """
-        Accounting routine for the parallel tasks, only used by :meth:`.run`.
-        Adapted for Dask futures.
-        """
-        if new_futures is not None:
-            for future in new_futures:
-                # Use future.key as identifier
-                self.pending[future.key] = future
-
-        # Find completed futures
-        self.new_finished = []
-        completed_keys = []
-
-        for future_id, future in list(self.pending.items()):
-            if future.done():
-                self.new_finished.append(future_id)
-                completed_keys.append(future_id)
-                self.finished.append(future_id)
-
-                # Calculate elapsed time if available
-                if hasattr(future, "done") and future.done():
-                    try:
-                        # Get task duration from Dask
-                        # Note: This is approximate, based on completion time
-                        self.tasks_walltimes[future_id] = 0.1  # placeholder
-                    except:
-                        pass
-
-        if time_module.time() - self.show_last > float(self.config.show_interval):
-            self.info()
-            self.show_last = time_module.time()
 
     def info(self):
         """ """

--- a/panobbgo/dask_evaluation.py
+++ b/panobbgo/dask_evaluation.py
@@ -1,0 +1,185 @@
+# -*- coding: utf8 -*-
+# Copyright 2026 Panobbgo Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Dask-based distributed evaluation backend
+=========================================
+
+Everything Dask-specific that used to live inline in :mod:`panobbgo.core`.
+``dask`` is imported lazily — only when a strategy actually runs with
+``evaluation_method = "dask"`` — so the rest of the framework carries no
+Dask code paths or import-time dependency.
+
+The functions operate on a :class:`~panobbgo.core.StrategyBase` instance and
+use the strategy's ``_client`` / ``_cluster`` / ``_problem_future``
+attributes, which tests and external code set/inspect directly.
+"""
+
+from __future__ import annotations
+
+import time as time_module
+from typing import TYPE_CHECKING, Any, List
+
+if TYPE_CHECKING:
+    from .core import StrategyBase
+
+
+def setup_cluster(strategy: "StrategyBase", problem: Any) -> None:
+    """
+    Set up a Dask cluster based on configuration.
+    Supports both local and remote clusters.
+    """
+    from dask.distributed import Client, LocalCluster
+
+    config = strategy.config
+    if config.dask_cluster_type == "local":
+        # Create a local cluster
+        strategy.logger.info("Setting up local Dask cluster with %d workers" % config.dask_n_workers)
+        strategy._cluster = LocalCluster(
+            n_workers=int(config.dask_n_workers),
+            threads_per_worker=int(config.dask_threads_per_worker),
+            memory_limit=str(config.dask_memory_limit),
+            dashboard_address=str(config.dask_dashboard_address),
+            silence_logs=False,
+        )
+        strategy._client = Client(strategy._cluster)
+    else:
+        # Connect to remote cluster
+        strategy.logger.info("Connecting to remote Dask cluster at %s" % config.dask_scheduler_address)
+        strategy._client = Client(config.dask_scheduler_address)
+
+    # Scatter the problem to all workers
+    strategy._problem_future = strategy._client.scatter(problem, broadcast=True)
+
+    strategy.logger.info("Dask cluster ready with %d workers" % len(strategy._client.scheduler_info()["workers"]))
+    if config.dask_cluster_type == "local":
+        strategy.logger.info("Dashboard available at: http://localhost%s" % config.dask_dashboard_address)
+
+
+class DaskEvaluators:
+    """
+    Evaluators view for the Dask backend (compatibility object for strategies
+    that reference ``strategy.evaluators``).
+    """
+
+    def __init__(self, strategy: "StrategyBase") -> None:
+        self.strategy = strategy
+
+    @property
+    def outstanding(self) -> List[str]:
+        # Return list of pending task keys
+        return list(self.strategy.pending.keys())
+
+    def __len__(self) -> int:
+        # Return number of Dask workers
+        if hasattr(self.strategy, "_client"):
+            return len(self.strategy._client.scheduler_info()["workers"])
+        return 0
+
+
+def run_evaluation(strategy: "StrategyBase", points: List[Any]) -> List[Any]:
+    """
+    Run evaluation using Dask distributed computing.
+
+    Submits each point as a Dask future, updates the strategy's task
+    accounting, and returns the newly finished results.
+    """
+
+    # Helper function to evaluate a point using the problem
+    def evaluate_point(problem, point):
+        """Evaluate a single point using the problem instance"""
+        return problem(point)
+
+    # distribute work using Dask futures
+    # Submit each point as a separate task
+    new_futures = []
+    for point in points:
+        future = strategy._client.submit(
+            evaluate_point,
+            strategy._problem_future,
+            point,
+            pure=False,  # Function may have side effects
+        )
+        new_futures.append(future)
+
+    # and don't forget, this updates the statistics
+    _add_tasks(strategy, new_futures)
+
+    # collect new results for each finished task, hand them over to result DB
+    new_results = []
+    for future_id in strategy.new_finished:
+        future = strategy.pending.pop(future_id, None)
+        if future is not None:
+            try:
+                result = future.result()
+                if isinstance(result, list):
+                    new_results.extend(result)
+                else:
+                    new_results.append(result)
+            except Exception as e:
+                strategy.logger.error("Task failed with error: %s" % e)
+
+    return new_results
+
+
+def _add_tasks(strategy: "StrategyBase", new_futures: List[Any]) -> None:
+    """
+    Accounting routine for the parallel Dask tasks
+    (moved from ``StrategyBase._add_tasks``).
+    """
+    if new_futures is not None:
+        for future in new_futures:
+            # Use future.key as identifier
+            strategy.pending[future.key] = future
+
+    # Find completed futures
+    strategy.new_finished = []
+    completed_keys = []
+
+    for future_id, future in list(strategy.pending.items()):
+        if future.done():
+            strategy.new_finished.append(future_id)
+            completed_keys.append(future_id)
+            strategy.finished.append(future_id)
+
+            # Calculate elapsed time if available
+            if hasattr(future, "done") and future.done():
+                try:
+                    # Get task duration from Dask
+                    # Note: This is approximate, based on completion time
+                    strategy.tasks_walltimes[future_id] = 0.1  # placeholder
+                except Exception:
+                    pass
+
+    if time_module.time() - strategy.show_last > float(strategy.config.show_interval):
+        strategy.info()
+        strategy.show_last = time_module.time()
+
+
+def close(strategy: "StrategyBase") -> None:
+    """
+    Cancel any outstanding Dask futures and close client + cluster.
+    """
+    for future in list(strategy.pending.values()):
+        try:
+            future.cancel()
+        except Exception:
+            pass
+
+    # Close Dask client and cluster
+    if hasattr(strategy, "_client"):
+        strategy._client.close()
+    if hasattr(strategy, "_cluster"):
+        strategy._cluster.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "pandas>=2.3",
     "scikit-learn>=1.8",
     "statsmodels>=0.14.6",
-    "dask[distributed]>=2026.1.1",
     "pyyaml>=6.0.3",
     "future",
     "rich>=14.2.0",
@@ -40,6 +39,11 @@ requires-python = ">=3.11"
 "Homepage" = "http://github.com/haraldschilly/panobbgo"
 
 [project.optional-dependencies]
+# Distributed evaluation backend (evaluation_method = "dask") — optional
+# since the framework only imports it lazily via panobbgo/dask_evaluation.py.
+dask = [
+    "dask[distributed]>=2026.1.1",
+]
 benchmark = [
     "coco-experiment>=2.6",
     # IOH (ioh>=0.3.22) lives in the isolated `tools/ioh_worker/` uv
@@ -55,6 +59,8 @@ dev = [
     # pytest-retry powers @pytest.mark.flaky — without it here, the markers
     # are a silent no-op in CI (which installs via `uv sync --extra dev`).
     "pytest-retry>=1.7.0",
+    # dask is an optional runtime extra; the dask backend tests need it.
+    "dask[distributed]>=2026.1.1",
     "flake8>=7.3",
     "ruff>=0.14.13",
     "mypy>=1.19",
@@ -102,6 +108,7 @@ reportPrivateImportUsage = "warning"
 
 [dependency-groups]
 dev = [
+    "dask[distributed]>=2026.1.1",
     "flake8>=7.3.0",
     "pyright>=1.1.407",
     "pytest-benchmark>=5.2.3",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-from dask.distributed import LocalCluster, Client
 
 
 @pytest.fixture
@@ -7,7 +6,11 @@ def dask_cluster():
     """
     Fixture that provides an isolated Dask cluster for testing.
     Ensures cleanup of workers to prevent memory leaks across tests.
+    Skips the test when the optional dask extra is not installed.
     """
+    distributed = pytest.importorskip("dask.distributed", reason="optional dask extra not installed")
+    LocalCluster, Client = distributed.LocalCluster, distributed.Client
+
     # Start a clean cluster
     # Use different dashboard port to avoid conflicts
     cluster = LocalCluster(n_workers=2, threads_per_worker=1, dashboard_address=":0", silence_logs=True)
@@ -27,6 +30,14 @@ def dask_cluster():
     import time
 
     time.sleep(0.5)
+
+    # Tests using this fixture mutate the singleton Config
+    # (evaluation_method="dask", dashboard_address=<full URL>). Reset it so a
+    # later test's strategy constructor doesn't try to start a LocalCluster
+    # with the stale URL as dashboard_address (order-dependent RuntimeError).
+    from panobbgo.config import Config
+
+    Config._instance = None
 
 
 @pytest.fixture

--- a/tests/test_dask_isolation.py
+++ b/tests/test_dask_isolation.py
@@ -1,7 +1,10 @@
 import psutil
+import pytest
 from panobbgo.lib.classic import Rosenbrock
 from panobbgo.core import StrategyBase
-from dask.distributed import Client
+
+distributed = pytest.importorskip("dask.distributed", reason="optional dask extra not installed")
+Client = distributed.Client
 
 
 class DummyStrategy(StrategyBase):

--- a/tests/test_heuristic_random.py
+++ b/tests/test_heuristic_random.py
@@ -1,0 +1,111 @@
+# -*- coding: utf8 -*-
+"""Branch tests for the Random heuristic's on_start paths.
+
+Random's point-generation loops run on an eventbus thread and depend on the
+Splitter analyzer's state; these tests drive `on_start` directly with scripted
+splitter stand-ins and stop the loops via a timer flipping `_stopped`.
+"""
+
+from __future__ import unicode_literals
+
+import threading
+import types
+
+import numpy as np
+
+from panobbgo.utils import PanobbgoTestCase
+
+
+def _stop_soon(h, delay=0.15):
+    """Flip the heuristic's stop flag shortly after the loop starts."""
+    threading.Timer(delay, lambda: setattr(h, "_stopped", True)).start()
+
+
+class RandomHeuristicBranchTest(PanobbgoTestCase):
+    def make_random(self):
+        from panobbgo.heuristics import Random
+
+        return Random(self.strategy)
+
+    def test_no_splitter_falls_back_to_full_problem_space(self):
+        """No Splitter analyzer at all → warning + sampling from the full box."""
+        h = self.make_random()
+        self.strategy.analyzer.side_effect = Exception("no analyzer registered")
+        # Don't actually wait 5 s for a split that will never come.
+        h.first_split.wait = lambda timeout=None: False
+
+        _stop_soon(h)
+        h.on_start()
+
+        points = h.get_points()
+        assert len(points) > 0, "fallback loop emitted no points"
+
+    def test_split_available_but_no_leaf_falls_back(self):
+        """first_split set but leaf is None → second fallback loop."""
+        h = self.make_random()
+        # Splitter without a `root` attribute → leaf stays None in on_start.
+        self.strategy.analyzer.side_effect = None
+        self.strategy.analyzer.return_value = object()
+        h.first_split.set()
+
+        _stop_soon(h)
+        h.on_start()
+
+        assert h.leaf is None
+        points = h.get_points()
+        assert len(points) > 0, "leafless fallback loop emitted no points"
+
+    def test_samples_from_leaf_box(self):
+        """With a root leaf available, points come from the leaf's box."""
+        h = self.make_random()
+        leaf = types.SimpleNamespace(
+            ranges=np.array([1.0, 1.0]),
+            box=np.array([[0.0, 1.0], [0.0, 1.0]]),
+        )
+        splitter = types.SimpleNamespace(root=leaf, dim=2)
+        self.strategy.analyzer.side_effect = None
+        self.strategy.analyzer.return_value = splitter
+
+        _stop_soon(h)
+        h.on_start()
+
+        assert h.leaf is leaf
+        points = h.get_points()
+        assert len(points) > 0, "leaf-based loop emitted no points"
+        for p in points:
+            assert np.all(p.x >= 0.0) and np.all(p.x <= 1.0), f"point {p.x} outside leaf box"
+
+    def test_on_restart_resets_to_root_leaf(self):
+        h = self.make_random()
+        root = object()
+        self.strategy.analyzer.side_effect = None
+        self.strategy.analyzer.return_value = types.SimpleNamespace(root=root)
+
+        h.first_split.clear()
+        h.on_restart(np.array([0.5, 0.5]), "stagnation")
+
+        assert h.leaf is root
+        assert h.first_split.is_set()
+
+
+class RandomNewSplitTest(PanobbgoTestCase):
+    def test_on_new_split_tracks_best_leaf(self):
+        from unittest import mock
+
+        from panobbgo.heuristics import Random
+
+        h = Random(self.strategy)
+        leaf = object()
+        best = types.SimpleNamespace(x=np.array([0.5, 0.5]))
+
+        def analyzer(name):
+            if name == "Best":
+                return types.SimpleNamespace(best=best)
+            return types.SimpleNamespace(get_leaf=mock.Mock(return_value=leaf))
+
+        self.strategy.analyzer.side_effect = analyzer
+        h.first_split.clear()
+        h.on_new_split(box=None, children=[], dim=0)
+
+        assert h.leaf is leaf
+        assert h.first_split.is_set()

--- a/tests/test_heuristics_local_penalty.py
+++ b/tests/test_heuristics_local_penalty.py
@@ -96,3 +96,252 @@ class LocalPenaltySearchTest(PanobbgoTestCase):
         h._stopped = True
         h.__stop__()
         t.join(timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# In-process tests for the subprocess worker function.
+#
+# The worker normally runs in a *spawned* process (invisible to coverage and
+# hard to assert against), so these tests drive `_local_penalty_search_worker`
+# directly in the main process through a scripted pipe object.
+# ---------------------------------------------------------------------------
+
+
+class ScriptedPipe:
+    """Mimics one end of a multiprocessing Pipe with a scripted conversation.
+
+    Messages the worker `recv()`s come from `inbox`; everything the worker
+    `send()`s is recorded in `sent`. Eval requests are answered according to
+    `eval_reply` ("result" computes a sphere value; "abort"/"stop" inject the
+    respective control message; a non-float value provokes an optimizer error).
+    """
+
+    def __init__(self, inbox=None, eval_reply="result"):
+        self.inbox = list(inbox or [])
+        self.sent = []
+        self.eval_reply = eval_reply
+
+    def poll(self, timeout=None):
+        if not self.inbox:
+            # Script exhausted — behave like a closed pipe so every code
+            # path terminates instead of polling an empty inbox forever.
+            raise EOFError
+        return True
+
+    def recv(self):
+        return self.inbox.pop(0)
+
+    def send(self, msg):
+        self.sent.append(msg)
+        if msg["type"] == "eval":
+            if self.eval_reply == "result":
+                val = float(np.sum(np.asarray(msg["x"], dtype=float) ** 2))
+                self.inbox.append({"type": "result", "value": val})
+            elif self.eval_reply == "garbage":
+                self.inbox.append({"type": "result", "value": "not-a-number"})
+            else:  # "abort" or "stop"
+                self.inbox.append({"type": self.eval_reply})
+        elif msg["type"] in ("done", "error"):
+            # End the worker loop after the optimization concludes.
+            self.inbox.append({"type": "stop"})
+
+
+def _run_worker(pipe, dim=1):
+    from panobbgo.heuristics.local_penalty_search import _local_penalty_search_worker
+
+    bounds = [(-5.0, 5.0)] * dim
+    _local_penalty_search_worker(pipe, "Nelder-Mead", dim, bounds, max_iter=5)
+
+
+def test_worker_stop_message_exits():
+    pipe = ScriptedPipe(inbox=[{"type": "stop"}])
+    _run_worker(pipe)
+    assert pipe.sent == []
+
+
+def test_worker_full_optimization_run():
+    pipe = ScriptedPipe(inbox=[{"type": "start", "x0": np.array([2.0])}])
+    _run_worker(pipe)
+
+    evals = [m for m in pipe.sent if m["type"] == "eval"]
+    dones = [m for m in pipe.sent if m["type"] == "done"]
+    assert len(evals) > 0, "worker never requested an evaluation"
+    assert len(dones) == 1, "worker did not report completion"
+
+
+def test_worker_abort_during_eval():
+    pipe = ScriptedPipe(inbox=[{"type": "start", "x0": np.array([2.0])}], eval_reply="abort")
+    _run_worker(pipe)
+
+    # Aborted optimizations end silently — no done/error message.
+    assert not [m for m in pipe.sent if m["type"] in ("done", "error")]
+
+
+def test_worker_stop_during_eval():
+    pipe = ScriptedPipe(inbox=[{"type": "start", "x0": np.array([2.0])}], eval_reply="stop")
+    _run_worker(pipe)
+    assert not [m for m in pipe.sent if m["type"] in ("done", "error")]
+
+
+def test_worker_optimizer_error_reported():
+    # A non-numeric objective value makes scipy blow up -> worker sends "error".
+    pipe = ScriptedPipe(inbox=[{"type": "start", "x0": np.array([2.0])}], eval_reply="garbage")
+    _run_worker(pipe)
+    assert [m for m in pipe.sent if m["type"] == "error"], "worker did not report the optimizer error"
+
+
+def test_worker_pipe_eof_exits():
+    class EOFPipe:
+        def poll(self, timeout=None):
+            raise EOFError
+
+    _run_worker(EOFPipe())  # must simply return, not raise
+
+
+# ---------------------------------------------------------------------------
+# Branch tests for the heuristic side (no subprocess spawned).
+# ---------------------------------------------------------------------------
+
+
+class LocalPenaltySearchBranchTest(PanobbgoTestCase):
+    def setUp(self):
+        super().setUp()
+        from unittest import mock
+
+        self.strategy.constraint_handler = MockConstraintHandler()
+        self.mock = mock
+
+    def make_heuristic(self):
+        from panobbgo.heuristics.local_penalty_search import LocalPenaltySearch
+
+        h = LocalPenaltySearch(self.strategy)
+        # No __start__() — tests drive the pipe directly, no subprocess.
+        h.parent_conn = self.mock.MagicMock()
+        return h
+
+    def test_emit_reliable_returns_false_when_stopped(self):
+        h = self.make_heuristic()
+        h._stopped = True
+        assert h.emit_reliable(np.array([0.0, 0.0])) is False
+
+    def test_emit_reliable_retries_on_full_queue(self):
+        import queue
+        import threading
+
+        h = self.make_heuristic()
+        h._output = queue.Queue(1)
+        h._output.put("blocker")
+
+        # Free the queue only after emit_reliable's first 1.0s put() timed
+        # out, so the `except Full: continue` retry path actually executes.
+        threading.Timer(1.2, lambda: h._output.get()).start()
+        assert h.emit_reliable(np.array([0.0, 0.0])) is True
+
+    def test_start_optimization_send_failure_logged(self):
+        h = self.make_heuristic()
+        h.parent_conn.send.side_effect = OSError("pipe broke")
+        h._start_optimization(np.array([0.0, 0.0]))
+        assert h._optimization_active is False
+
+    def test_on_restart_aborts_and_restarts(self):
+        h = self.make_heuristic()
+        h._optimization_active = True
+        h.on_restart(np.array([0.1, 0.2]), "test restart")
+
+        types = [c.args[0]["type"] for c in h.parent_conn.send.call_args_list]
+        assert types == ["abort", "start"]
+        assert h._optimization_active is True
+
+    def test_on_restart_survives_abort_send_failure(self):
+        h = self.make_heuristic()
+        h.parent_conn.send.side_effect = [OSError("gone"), None]
+        h.on_restart(np.array([0.1, 0.2]), "test restart")
+        assert h._optimization_active is True
+
+    def test_on_new_best_restarts_when_idle(self):
+        h = self.make_heuristic()
+        best = Result(Point(np.array([0.5, 0.5]), "test"), 1.0)
+        h.on_new_best(best)
+        assert h._optimization_active is True
+        assert h.parent_conn.send.call_args[0][0]["type"] == "start"
+
+    def test_on_new_results_ignored_when_not_waiting(self):
+        h = self.make_heuristic()
+        r = Result(Point(np.array([0.5, 0.5]), h.name), 1.0)
+        h.on_new_results([r])
+        h.parent_conn.send.assert_not_called()
+
+    def test_on_new_results_ignores_foreign_results(self):
+        h = self.make_heuristic()
+        h._waiting_for_eval = True
+        r = Result(Point(np.array([0.5, 0.5]), "SomeoneElse"), 1.0)
+        h.on_new_results([r])
+        h.parent_conn.send.assert_not_called()
+        assert h._waiting_for_eval is True
+
+    def test_on_new_results_sends_penalty_value(self):
+        h = self.make_heuristic()
+        h._waiting_for_eval = True
+        r = Result(Point(np.array([0.5, 0.5]), h.name), 2.5)
+        h.on_new_results([r])
+
+        msg = h.parent_conn.send.call_args[0][0]
+        assert msg["type"] == "result"
+        assert msg["value"] == 2.5
+        assert h._waiting_for_eval is False
+
+    def test_on_new_results_send_failure_logged(self):
+        h = self.make_heuristic()
+        h._waiting_for_eval = True
+        h.parent_conn.send.side_effect = OSError("pipe broke")
+        r = Result(Point(np.array([0.5, 0.5]), h.name), 2.5)
+        h.on_new_results([r])  # must not raise
+
+    def test_on_start_loop_handles_messages(self):
+        # Script: eval -> done -> error -> EOF (breaks the loop).
+        h = self.make_heuristic()
+        msgs = [
+            {"type": "eval", "x": np.array([0.3, 0.3])},
+            {"type": "done", "message": "converged"},
+            {"type": "error", "message": "boom"},
+        ]
+
+        def poll(timeout=None):
+            if msgs:
+                return True
+            raise EOFError
+
+        h.parent_conn.poll.side_effect = poll
+        h.parent_conn.recv.side_effect = lambda: msgs.pop(0)
+
+        h.on_start()  # returns via the EOF branch
+
+        # The eval message must have produced an emitted point.
+        assert len(h.get_points()) == 1
+        assert h._optimization_active is False
+
+
+def test_worker_eval_send_failure_aborts_optimization():
+    """pipe.send failing inside the objective → StopIteration → silent end."""
+
+    class SendFailsOnEval(ScriptedPipe):
+        def send(self, msg):
+            if msg["type"] == "eval":
+                raise OSError("pipe broke")
+            super().send(msg)
+
+    pipe = SendFailsOnEval(inbox=[{"type": "start", "x0": np.array([2.0])}])
+    _run_worker(pipe)
+    assert not [m for m in pipe.sent if m["type"] in ("done", "error")]
+
+
+def test_worker_unexpected_recv_error_exits():
+    """A non-EOF error in the outer loop must break it, not crash."""
+
+    class RecvBlowsUp(ScriptedPipe):
+        def recv(self):
+            raise ValueError("corrupted message")
+
+    pipe = RecvBlowsUp(inbox=[{"type": "start", "x0": np.array([2.0])}])
+    _run_worker(pipe)  # must return, not raise
+    assert pipe.sent == []

--- a/uv.lock
+++ b/uv.lock
@@ -1159,7 +1159,6 @@ version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "cocopp" },
-    { name = "dask", extra = ["distributed"] },
     { name = "future" },
     { name = "matplotlib" },
     { name = "numpy" },
@@ -1176,7 +1175,11 @@ dependencies = [
 benchmark = [
     { name = "coco-experiment" },
 ]
+dask = [
+    { name = "dask", extra = ["distributed"] },
+]
 dev = [
+    { name = "dask", extra = ["distributed"] },
     { name = "flake8" },
     { name = "mypy" },
     { name = "pandas-stubs" },
@@ -1195,6 +1198,7 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "dask", extra = ["distributed"] },
     { name = "flake8" },
     { name = "pyright" },
     { name = "pytest-benchmark" },
@@ -1210,7 +1214,8 @@ dev = [
 requires-dist = [
     { name = "coco-experiment", marker = "extra == 'benchmark'", specifier = ">=2.6" },
     { name = "cocopp", specifier = ">=2.8.2" },
-    { name = "dask", extras = ["distributed"], specifier = ">=2026.1.1" },
+    { name = "dask", extras = ["distributed"], marker = "extra == 'dask'", specifier = ">=2026.1.1" },
+    { name = "dask", extras = ["distributed"], marker = "extra == 'dev'", specifier = ">=2026.1.1" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=7.3" },
     { name = "future" },
     { name = "matplotlib", specifier = ">=3.10" },
@@ -1235,10 +1240,11 @@ requires-dist = [
     { name = "statsmodels", specifier = ">=0.14.6" },
     { name = "types-setuptools", marker = "extra == 'dev'" },
 ]
-provides-extras = ["benchmark", "dev"]
+provides-extras = ["dask", "benchmark", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "dask", extras = ["distributed"], specifier = ">=2026.1.1" },
     { name = "flake8", specifier = ">=7.3.0" },
     { name = "pyright", specifier = ">=1.1.407" },
     { name = "pytest-benchmark", specifier = ">=4.0" },


### PR DESCRIPTION
## Summary

Follow-up to the coverage discussion after #243 (overall suite coverage 84%).

### 1. Dask extracted out of `core.py` → `panobbgo/dask_evaluation.py`

We effectively never use Dask, so `core.py` no longer carries its code: cluster setup, the evaluation step, future accounting (`_add_tasks`), the evaluators view and cleanup all move to a dedicated module, imported **lazily** at three call sites — only when a strategy actually runs with `evaluation_method="dask"`.

- Functionality is preserved: `evaluation_method="dask"` works as before; all dask tests pass unchanged.
- The `_client` / `_cluster` / `_problem_future` strategy attributes keep their names (tests assign them directly); now declared on `StrategyBase` for pyright.
- `core.py` shrinks by ~130 lines of backend-specific code.

### 2. Dask is now an **optional extra**

With the code isolated and lazily imported, `dask[distributed]` moved from core dependencies to `[project.optional-dependencies] dask` — regular installs no longer pull distributed/tornado/etc. Both dev sets include it, so CI and local `uv sync` still run the dask tests; without it they **skip** cleanly (`pytest.importorskip`). Verified the framework imports and runs threaded strategies with all `dask` imports blocked.

```bash
pip install "panobbgo[dask]"   # or: uv sync --extra dask
```

### 3. Order-dependent dask test flake — root-caused and fixed

`test_dask_evaluation_integration` failed when run right after `test_dask_isolation.py`: both mutate the **singleton `Config`** (`evaluation_method="dask"` + a full dashboard *URL* in `dask_dashboard_address`). The next test's strategy *constructor* then tried to start its own `LocalCluster` with that URL as `dashboard_address` → `RuntimeError: Cluster failed to start: ['http', '//127.0.0.1', ...]`. The `dask_cluster` fixture now resets `Config._instance` at teardown; both orders pass.

### 4. Coverage: the two weakest non-optional heuristics

| file | before | after (file-local) |
|---|---|---|
| `heuristics/local_penalty_search.py` | 51% | **88%** |
| `heuristics/random.py` | 61% | **84%** |

- The subprocess worker `_local_penalty_search_worker` was invisible to coverage (it runs in a *spawned* process). It is now driven **in-process** through a `ScriptedPipe`: full optimization runs plus the abort / stop / optimizer-error / EOF / send-failure paths.
- Heuristic-side branch tests: `emit_reliable` stop & queue-full retry, the `on_start` message loop (eval/done/error/EOF), `on_restart` abort handshake, `on_new_best` idle restart, `on_new_results` filtering and pipe-failure handling.
- `Random`: both `on_start` fallback loops (no Splitter / no leaf), leaf-box sampling bounds, `on_restart` root reset, `on_new_split` leaf tracking.

Remaining uncovered lines in both files are defensive dead branches (`emit()` never raises, the scipy import guard, the 10-minute pipe timeout).

### 5. Docs

`guide_architecture` / `guide_usage` now point to `panobbgo.dask_evaluation` and the `dask` extra; stale requirement "Python ≥ 3.8" corrected to 3.11; `core.rst` gained an autodoc section for the new module.

---

24 new tests; full suite: 1397 passed locally in ~4:40 serial / under 30 s with `-n auto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)