### PR TITLE
feat(heuristics): RegionUCB — UCB1 allocation over Splitter leaves

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,40 @@
 
 ## Recent Improvements (continued)
 
+### RegionUCB heuristic — UCB1 allocation over Splitter leaves — 2026-06-05
+- [x] **New heuristic `panobbgo/heuristics/region_ucb.py`** (`RegionUCB`):
+      treats the Splitter tree's leaves as bandit arms (LA-MCTS / DIRECT
+      spirit), selects a leaf via a UCB1-style score
+      (rank-based quality from the leaf's best penalty + `ucb_c *
+      sqrt(log N / n_leaf)`; empty leaves first), and samples
+      candidates *inside* the chosen box (uniform + Gaussian around the
+      leaf best, clipped).  Because placement is steered by the heuristic
+      itself, the existing strategy-level bandits handle credit
+      assignment with no core changes.
+- [x] **Harness wiring** — `Rewarding_RegionUCB` spec in
+      `_make_standard_strategies()` (= `Rewarding_Diverse` pool +
+      `RegionUCB` arm, so the score delta isolates region allocation).
+      Deliberately *not* in quick mode: at 75 evals the Splitter yields
+      too few leaves to matter (15-rep quick A/B was a tie), and
+      `test_quick_strategies_unchanged` guards quick mode at 2 specs.
+- [x] **Measured (standard mode, 10 reps, seed 42)** —
+      StyblinskiTang_2D +0.302 score (SR 0.20→0.50), Rosenbrock_2D
+      −0.167 (exploration tax on a unimodal valley), others tied;
+      net per-strategy mean +0.019 vs `Rewarding_Diverse`.  Rosenbrock_5D
+      median distance halved (9.64→4.97) without reaching tolerance.
+      Artifacts: `ab_region_ucb_standard.json`.
+- **Design rationale.**  Replaces the per-region *strategy* prototype
+  (parked in `sketchpad/grok_per_region_bandit_strategy.py`): a
+  strategy-level per-leaf bandit cannot steer point placement because
+  heuristics autonomously push into their output queues — the strategy
+  only chooses whose queue to drain — and selection/reward then operate
+  on different leaves.  Inverting the decomposition (bandit over
+  *regions* inside a heuristic, strategy bandit over *heuristics* as
+  before) keeps statistics dense and needs no `StrategyBase` changes.
+- **Follow-ups**: tune `ucb_c` / `gauss_fraction` via the
+  self-improvement catalog; consider volume-aware exploration term
+  (DIRECT-style) and parent-posterior inheritance on splits.
+
 ### Stochastic-K stagnation rebuild for the random PSO topology — 2026-06-05
 - [x] **Opt-in `PSO.stagnation_threshold` kwarg** in
       `panobbgo/heuristics/pso.py`; closes the *Per-iteration

--- a/panobbgo/harness.py
+++ b/panobbgo/harness.py
@@ -317,7 +317,17 @@ def _make_quick_strategies() -> List[StrategySpec]:
 
 
 def _make_standard_strategies() -> List[StrategySpec]:
-    """Six strategies: baseline, adaptive, UCB bandit, Bayesian GP, CMA-ES portfolio, IPOP-CMA-ES.
+    """Seven strategies: baseline, adaptive, region bandit, UCB bandit, Bayesian GP, CMA-ES portfolio, IPOP-CMA-ES.
+
+    Rewarding_RegionUCB is ``Rewarding_Diverse`` plus the
+    :class:`~panobbgo.heuristics.RegionUCB` arm (UCB1 allocation over
+    Splitter leaves with in-leaf sampling), so the per-strategy score delta
+    between the two isolates the effect of region-level allocation.
+    Registered in standard mode (not quick) because at 75 evals the
+    Splitter produces too few leaves for region allocation to matter
+    (measured 2026-06-05: quick A/B with 15 reps was a tie; standard A/B
+    with 10 reps gave +0.30 on StyblinskiTang_2D, -0.17 on Rosenbrock_2D,
+    net +0.02 — the classic multimodal-win / unimodal-tax signature).
 
     BayesOpt_GP uses a Gaussian Process surrogate (Expected Improvement acquisition)
     paired with LatinHypercube initialization.  With 200 evaluations the GP model
@@ -342,10 +352,27 @@ def _make_standard_strategies() -> List[StrategySpec]:
         Sobol,
         GaussianProcessHeuristic,
         CMAES,
+        Center,
+        RegionUCB,
     )
     from panobbgo.analyzers import Sensitivity, Restart
 
     quick = _make_quick_strategies()
+    region_ucb = StrategySpec(
+        name="Rewarding_RegionUCB",
+        strategy_class=StrategyRewarding,
+        heuristics=[
+            # Identical pool to ``Rewarding_Diverse`` plus the RegionUCB arm —
+            # see the docstring above and panobbgo/heuristics/region_ucb.py.
+            (Sobol, {"n": 16, "scramble": False}),
+            (Random, {}),
+            (Nearby, {"radius": 0.1, "axes": "all", "new": 3}),
+            (Center, {}),
+            (NelderMead, {}),
+            (RegionUCB, {}),
+        ],
+        analyzers=[(Sensitivity, {"update_interval": 25})],
+    )
     ucb = StrategySpec(
         name="UCB_Diverse",
         strategy_class=StrategyUCB,
@@ -413,7 +440,7 @@ def _make_standard_strategies() -> List[StrategySpec]:
             (Sensitivity, {"update_interval": 20}),
         ],
     )
-    return quick + [ucb, bayes_gp, bayes_sobol, cmaes_portfolio, ipop_cmaes]
+    return quick + [region_ucb, ucb, bayes_gp, bayes_sobol, cmaes_portfolio, ipop_cmaes]
 
 
 def _make_full_strategies() -> List[StrategySpec]:

--- a/panobbgo/heuristics/__init__.py
+++ b/panobbgo/heuristics/__init__.py
@@ -50,6 +50,7 @@ from .repair import ConstraintRepair
 from .cma_es import CMAES
 from .pso import PSO
 from .cobyqa import COBYQA
+from .region_ucb import RegionUCB
 
 __all__ = [
     "Center",
@@ -78,4 +79,5 @@ __all__ = [
     "CMAES",
     "PSO",
     "COBYQA",
+    "RegionUCB",
 ]

--- a/panobbgo/heuristics/region_ucb.py
+++ b/panobbgo/heuristics/region_ucb.py
@@ -1,0 +1,168 @@
+# -*- coding: utf8 -*-
+# Copyright 2012-2026 Panobbgo Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+RegionUCB Heuristic
+===================
+
+A region-allocation heuristic in the spirit of LA-MCTS / DIRECT: it treats
+the leaves of the :class:`~panobbgo.analyzers.splitter.Splitter` tree as
+bandit arms, selects a leaf via a UCB1-style score, and samples new
+candidate points *inside* the chosen leaf.
+
+This differs from the existing :class:`~panobbgo.heuristics.Random`
+heuristic (which only samples the leaf around the global best) by
+allocating evaluations across *all* regions — exploiting good leaves while
+still visiting under-sampled ones.
+
+Because it is a plain :class:`~panobbgo.core.Heuristic`, it composes with
+every existing strategy: the strategy-level bandit (Rewarding / UCB /
+Thompson) learns *whether* region-level allocation helps, while RegionUCB
+learns *where* to sample.  Placement is steered directly (points are drawn
+inside the selected box), so credit assignment needs no extra machinery.
+
+**Leaf score** (higher is better)::
+
+    score(leaf) = quality(leaf) + ucb_c * sqrt(log(N) / n_leaf)
+
+- ``quality``: rank-based in [0, 1] from the leaf's best penalty value
+  (constraint-aware via the strategy's constraint handler).  Rank-based
+  normalization is scale-free, so it works for arbitrary objectives.
+- ``n_leaf``: number of evaluated points inside the leaf; ``N``: total.
+- Leaves with no points score ``+inf`` and are explored first
+  (random tie-break).
+
+**In-leaf sampling**: a mix of uniform draws over the leaf box and
+Gaussian draws around the leaf's best point (clipped to the box), so both
+fresh exploration and local refinement happen inside the chosen region.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from panobbgo.core import Heuristic
+
+
+class RegionUCB(Heuristic):
+    """
+    UCB1 allocation over Splitter leaves with in-leaf sampling.
+
+    Args:
+        strategy: The strategy instance (provides Splitter, constraint handler).
+        ucb_c (float): Exploration weight in the UCB score (default 1.0).
+        n_candidates (int): Points emitted per ``new_results`` event (default 5).
+        gauss_fraction (float): Fraction of candidates drawn from a Gaussian
+            around the leaf's best point instead of uniformly (default 0.5).
+        gauss_scale (float): Std-dev of that Gaussian, relative to the leaf's
+            ranges (default 0.25).
+    """
+
+    def __init__(self, strategy, ucb_c=1.0, n_candidates=5, gauss_fraction=0.5, gauss_scale=0.25, name=None):
+        name = "RegionUCB" if name is None else name
+        Heuristic.__init__(self, strategy, name=name)
+        self.logger = self.config.get_logger("RUCB")
+        self.ucb_c = float(ucb_c)
+        self.n_candidates = int(n_candidates)
+        self.gauss_fraction = float(gauss_fraction)
+        self.gauss_scale = float(gauss_scale)
+
+    # -- helpers ----------------------------------------------------------
+
+    @staticmethod
+    def _box_array(leaf):
+        """Return the (dim, 2) bounds array of a Splitter.Box."""
+        box = leaf.box
+        return box.box if hasattr(box, "box") else box
+
+    def _leaf_penalty(self, leaf):
+        """Best penalty value in the leaf (constraint-aware), or +inf if empty."""
+        if leaf.best is None:
+            return float("inf")
+        handler = getattr(self.strategy, "constraint_handler", None)
+        if handler is not None:
+            try:
+                return handler.get_penalty_value(leaf.best)
+            except Exception:
+                pass
+        fx = leaf.best.fx
+        return float("inf") if fx is None else fx
+
+    def select_leaf(self, leafs):
+        """
+        Pick a leaf by UCB1 score; empty leaves win immediately (random
+        tie-break among them).
+        """
+        counts = np.array([len(leaf) for leaf in leafs], dtype=float)
+        total = counts.sum()
+
+        empty = np.where(counts == 0)[0]
+        if len(empty) > 0:
+            return leafs[int(np.random.choice(empty))]
+
+        # rank-based quality in [0, 1]: best penalty -> 1, worst -> 0
+        penalties = np.array([self._leaf_penalty(leaf) for leaf in leafs])
+        order = np.argsort(np.argsort(penalties))  # rank, 0 = best
+        if len(leafs) > 1:
+            quality = 1.0 - order / (len(leafs) - 1.0)
+        else:
+            quality = np.ones(1)
+
+        explore = self.ucb_c * np.sqrt(np.log(max(total, 2.0)) / counts)
+        scores = quality + explore
+        return leafs[int(np.argmax(scores))]
+
+    def sample_in_leaf(self, leaf):
+        """Draw ``n_candidates`` points inside the leaf's box."""
+        box = self._box_array(leaf)
+        lo, ranges = box[:, 0], leaf.ranges
+        dim = len(lo)
+
+        n_gauss = 0
+        if leaf.best is not None:
+            n_gauss = int(round(self.n_candidates * self.gauss_fraction))
+        n_uniform = self.n_candidates - n_gauss
+
+        points = [lo + ranges * np.random.rand(dim) for _ in range(n_uniform)]
+        if n_gauss > 0:
+            sigma = np.maximum(ranges * self.gauss_scale, 1e-12)
+            for _ in range(n_gauss):
+                p = leaf.best.x + sigma * np.random.randn(dim)
+                points.append(np.clip(p, box[:, 0], box[:, 1]))
+        return points
+
+    # -- event handlers ----------------------------------------------------
+
+    def on_new_results(self, results):
+        """Re-select a region and refill the output queue on every batch."""
+        try:
+            splitter = self.strategy.analyzer("Splitter")
+            leafs = list(splitter.leafs)
+        except Exception:
+            leafs = []
+
+        if not leafs:
+            # No Splitter (yet) — sample the full problem box instead.
+            self.clear_output()
+            self.emit([self.problem.random_point() for _ in range(self.n_candidates)])
+            return
+
+        leaf = self.select_leaf(leafs)
+        points = self.sample_in_leaf(leaf)
+        self.clear_output()
+        self.emit(points)
+        self.logger.debug(
+            "leaf id=%s depth=%s n=%d -> emitted %d points" % (leaf.id, leaf.depth, len(leaf), len(points))
+        )

--- a/sketchpad/grok_per_region_bandit_strategy.py
+++ b/sketchpad/grok_per_region_bandit_strategy.py
@@ -1,0 +1,275 @@
+# -*- coding: utf8 -*-
+# Copyright 2012-2026 Panobbgo Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Per-Region Bandit Strategy
+==========================
+
+A spatially-aware bandit strategy that maintains independent multi-armed
+bandits (Thompson Sampling style) for each leaf region identified by the
+Splitter analyzer.
+
+**Rationale**
+
+- The global bandit (StrategyUCB / StrategyThompsonSampling / StrategyRewarding)
+  uses a single set of performance statistics for the entire search space.
+- Different regions of the landscape often require different heuristics:
+  - Smooth valley → local optimizer (NelderMead, LBFGSB, COBYQA)
+  - Multimodal basin → global DE-family or Sobol exploration
+  - High-density cluster → Nearby perturbation or Restart
+
+By scoping a bandit per Splitter.Box leaf, the strategy learns *locally*
+optimal heuristic allocation while sharing the global heuristic pool and
+the Splitter's hierarchical decomposition.
+
+**Implementation notes (prototype)**
+
+- Reuses the reward/improvement logic from StrategyThompsonSampling.
+- Each leaf maintains its own ``ts_total_reward`` / ``ts_counts`` per heuristic.
+- On ``execute()`` we lookup the current "biggest_leaf" (or best_box) and
+  delegate selection to that leaf's bandit.
+- Falls back to global Thompson if no Splitter leaf is available (e.g. early
+  in the run).
+- Respects pending evaluation budget accounting via the inherited
+  ``_collect_points_safely`` and ``evaluators.outstanding`` logic.
+- No changes to Splitter.Box or existing heuristics — minimal surface area.
+
+This is the first step toward a full per-region adaptive portfolio. Future
+work can add per-leaf heuristic subsets, region-specific config, or
+hierarchical borrowing from parent boxes.
+
+See AGENTS.md, benchmark_harness.py, and planning/SELF_IMPROVEMENT_LOOP.md
+for measurement requirements.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+from panobbgo.core import StrategyBase, Result
+
+
+class StrategyPerRegionBandit(StrategyBase):
+    """
+    Per-region Thompson Sampling bandit.
+
+    Maintains an independent Beta-Bernoulli bandit (alpha/beta derived from
+    accumulated reward and selection count) for each leaf box returned by
+    the Splitter analyzer's ``get_leaf()`` / ``biggest_leaf``.
+
+    Selection always queries the bandit belonging to the *current biggest
+    leaf* (the one with largest log-volume, i.e. the least-explored region).
+    This biases the search toward under-explored spatial regions while
+    letting the per-region bandit decide *which heuristic* to use there.
+
+    Inherits all budget accounting, Dask/threaded evaluation, constraint
+    handling, and event-bus integration from StrategyBase.
+    """
+
+    def __init__(self, problem, **kwargs):
+        """
+        Initialize the per-region bandit strategy.
+
+        Args:
+            problem: The optimization problem instance.
+            **kwargs: Passed to StrategyBase (max_eval, config overrides, etc.).
+        """
+        self.last_best: Optional[Result] = None
+        self.total_selections: int = 0
+
+        # Per-leaf bandit state: leaf_id -> heuristic_name -> (total_reward, count)
+        # We key by leaf.id (unique per Splitter.Box) so splits create fresh
+        # bandits for child regions.
+        self._leaf_bandits: Dict[int, Dict[str, Dict[str, float]]] = defaultdict(
+            lambda: defaultdict(lambda: {"total_reward": 0.0, "count": 0})
+        )
+
+        # Cache of leaf objects for quick lookup
+        self._leaf_cache: Dict[int, Any] = {}
+
+        StrategyBase.__init__(self, problem, **kwargs)
+
+    def add_heuristic(self, h):
+        """Register heuristic and ensure it has bandit stats (global fallback)."""
+        StrategyBase.add_heuristic(self, h)
+        # Global fallback stats (used if no Splitter leaf yet)
+        if not hasattr(h, "ts_total_reward"):
+            h.ts_total_reward = 0.0
+            h.ts_counts = 0
+
+    def _get_reward(self, best: Result) -> float:
+        """
+        Compute bounded reward [0,1] from improvement over current best.
+
+        Matches the reward function used in StrategyThompsonSampling and
+        StrategyUCB for consistency with the self-improvement ledger.
+        """
+        if self.last_best is None:
+            return 1.0
+
+        improvement = self.constraint_handler.calculate_improvement(self.last_best, best)
+        # Saturating transform used across bandit strategies
+        reward = 1.0 - np.exp(-1.0 * improvement)
+        return max(0.0, reward)
+
+    def on_new_best(self, best: Result) -> None:
+        """
+        Update the bandit statistics for the heuristic that produced the new best.
+
+        The leaf is determined from the Splitter using the result's location.
+        If no Splitter is present (or no leaf yet), falls back to global stats.
+        """
+        reward = self._get_reward(best)
+        self.last_best = best
+
+        try:
+            splitter = self.analyzer("Splitter")
+            leaf = splitter.get_leaf(best)
+            leaf_id = getattr(leaf, "id", 0)
+
+            # Update per-leaf bandit for the heuristic that produced this best
+            who = best.who.split(":")[0]  # strip any :g3:i0 suffix
+            bandit = self._leaf_bandits[leaf_id][who]
+            bandit["total_reward"] += reward
+            bandit["count"] += 1  # count the successful pull
+
+            self._leaf_cache[leaf_id] = leaf
+
+            self.logger.info(
+                f"PerRegionBandit: leaf={leaf_id} (depth={getattr(leaf, 'depth', 0)}) "
+                f"updated {who}: reward={reward:.4f} → total={bandit['total_reward']:.3f} "
+                f"count={bandit['count']}"
+            )
+        except (KeyError, AttributeError, Exception):
+            # Fallback: update global heuristic stats (early-run or no Splitter)
+            try:
+                h = self.heuristic(best.who)
+                if hasattr(h, "ts_total_reward"):
+                    h.ts_total_reward = getattr(h, "ts_total_reward", 0.0) + reward
+                    h.ts_counts = getattr(h, "ts_counts", 0) + 1
+            except Exception:
+                pass
+
+        self.logger.info("\u2318 %s | Δ %.7f %s (PerRegionBandit)" % (best, reward, best.who))
+
+    def _get_status_info(self) -> Dict[str, str]:
+        """Return strategy-specific status for logging (active leaves, etc.)."""
+        info = {}
+        active_leaves = len(self._leaf_bandits)
+        if active_leaves > 0:
+            info["regions"] = f"{active_leaves} leaves"
+            # Report the biggest leaf's bandit if available
+            try:
+                splitter = self.analyzer("Splitter")
+                biggest = getattr(splitter, "biggest_leaf", None)
+                if biggest is not None:
+                    leaf_id = getattr(biggest, "id", 0)
+                    info["biggest_leaf"] = f"id={leaf_id} depth={getattr(biggest, 'depth', 0)}"
+            except Exception:
+                pass
+        return info
+
+    def execute(self):
+        """
+        Main point-generation loop.
+
+        Queries the current biggest leaf (via Splitter.biggest_leaf or best_box)
+        and uses that leaf's per-region bandit to select which heuristic to
+        pull from. Falls back to global Thompson sampling if no leaf info yet.
+
+        Respects the pending-evaluation budget via the inherited
+        ``_collect_points_safely`` mechanism.
+        """
+        points = []
+        target = self.jobs_per_client * len(self.evaluators)
+
+        if len(self.evaluators.outstanding) < target:
+
+            def until(points, target):
+                return len(self.evaluators.outstanding) + len(points) >= target
+
+            def selector():
+                heurs = self.heuristics
+                if not heurs:
+                    return None
+
+                # Try to get current region (prefer biggest_leaf for exploration bias)
+                leaf_id = 0
+                try:
+                    splitter = self.analyzer("Splitter")
+                    # biggest_leaf is the least-explored (largest volume) region
+                    current_leaf = getattr(splitter, "biggest_leaf", None)
+                    if current_leaf is None:
+                        current_leaf = getattr(splitter, "best_box", None)
+                    if current_leaf is not None:
+                        leaf_id = getattr(current_leaf, "id", 0)
+                        self._leaf_cache[leaf_id] = current_leaf
+                except Exception:
+                    # No Splitter yet or error — use global fallback (leaf_id=0)
+                    pass
+
+                # Build per-heuristic scores from the selected leaf's bandit
+                samples = []
+                for h in heurs:
+                    hname = h.name
+                    bandit = self._leaf_bandits[leaf_id][hname]
+
+                    alpha = 1.0 + bandit["total_reward"]
+                    beta = 1.0 + max(0.0, bandit["count"] - bandit["total_reward"])
+
+                    # Thompson sample
+                    theta = np.random.beta(alpha, beta)
+                    samples.append((theta, h, alpha, beta))
+
+                # Pick highest sampled heuristic
+                samples.sort(key=lambda x: x[0], reverse=True)
+
+                for _, h, alpha, beta in samples:
+                    new_points = h.get_points(1)
+                    if new_points:
+                        count = len(new_points)
+                        # Update selection count immediately (increases beta)
+                        self._leaf_bandits[leaf_id][h.name]["count"] += count
+                        self.total_selections += count
+
+                        self.logger.debug(
+                            f"PerRegionBandit: leaf={leaf_id} selected {h.name} "
+                            f"(θ≈{samples[0][0]:.3f}, α={alpha:.1f}, β={beta:.1f})"
+                        )
+                        return new_points
+
+                return []
+
+            points = self._collect_points_safely(target, selector, until=until)
+
+        return points
+
+    def on_new_results(self, results: List[Result]) -> None:
+        """
+        Forward to base class (if it implements the method) and optionally
+        update per-leaf stats for non-best results (future extension).
+        Prototype keeps updates in on_new_best only for simplicity.
+        """
+        # StrategyBase does not declare on_new_results in its stub;
+        # we forward only if the concrete parent implements it.
+        if hasattr(StrategyBase, "on_new_results") or hasattr(self, "_on_new_results"):
+            # Use direct call to avoid super() attribute warning in static check
+            StrategyBase.on_new_results(self, results) if hasattr(StrategyBase, "on_new_results") else None
+
+        # Optional: could extend with near-best spatial rewards per leaf,
+        # but prototype keeps it simple — only on_new_best updates bandits.
+        pass

--- a/tests/test_heuristic_region_ucb.py
+++ b/tests/test_heuristic_region_ucb.py
@@ -1,0 +1,123 @@
+# -*- coding: utf8 -*-
+# Copyright 2012-2026 Panobbgo Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the RegionUCB heuristic (UCB over Splitter leaves)."""
+
+from __future__ import unicode_literals
+
+import numpy as np
+
+from panobbgo.utils import PanobbgoTestCase
+
+
+class _FakeLeaf:
+    """Minimal stand-in for Splitter.Box: bounds, results, best."""
+
+    _next_id = 0
+
+    def __init__(self, box, results=None, best=None, depth=1):
+        self.box = np.asarray(box, dtype=float)
+        self.results = results if results is not None else []
+        self.best = best
+        self.depth = depth
+        self.id = _FakeLeaf._next_id
+        _FakeLeaf._next_id += 1
+
+    @property
+    def ranges(self):
+        return np.ptp(self.box, axis=1)
+
+    def __len__(self):
+        return len(self.results)
+
+
+class _FakeBest:
+    def __init__(self, x, fx):
+        self.x = np.asarray(x, dtype=float)
+        self.fx = fx
+        self.cv = 0.0
+
+
+class RegionUCBTest(PanobbgoTestCase):
+    def make_heuristic(self, **kwargs):
+        from panobbgo.heuristics import RegionUCB
+
+        h = RegionUCB(self.strategy, **kwargs)
+        # PanobbgoTestCase mocks the strategy; constraint handler off
+        self.strategy.constraint_handler = None
+        return h
+
+    def test_empty_leaf_selected_first(self):
+        """A leaf with no points must win over any populated leaf."""
+        h = self.make_heuristic()
+        full = _FakeLeaf([[0, 1], [0, 1]], results=[object()] * 10, best=_FakeBest([0.5, 0.5], 0.0))
+        empty = _FakeLeaf([[1, 2], [1, 2]])
+        assert h.select_leaf([full, empty]) is empty
+
+    def test_best_leaf_preferred_at_equal_counts(self):
+        """With equal counts, the leaf with better fx has the higher score."""
+        h = self.make_heuristic(ucb_c=0.1)
+        good = _FakeLeaf([[0, 1], [0, 1]], results=[object()] * 5, best=_FakeBest([0.5, 0.5], 1.0))
+        bad = _FakeLeaf([[1, 2], [1, 2]], results=[object()] * 5, best=_FakeBest([1.5, 1.5], 100.0))
+        assert h.select_leaf([good, bad]) is good
+
+    def test_exploration_term_lifts_undersampled_leaf(self):
+        """A much-less-sampled leaf wins when ucb_c is large."""
+        h = self.make_heuristic(ucb_c=10.0)
+        exploited = _FakeLeaf([[0, 1], [0, 1]], results=[object()] * 100, best=_FakeBest([0.5, 0.5], 0.0))
+        fresh = _FakeLeaf([[1, 2], [1, 2]], results=[object()] * 2, best=_FakeBest([1.5, 1.5], 50.0))
+        assert h.select_leaf([exploited, fresh]) is fresh
+
+    def test_samples_stay_inside_leaf_box(self):
+        """All sampled points (uniform + gaussian) lie within the leaf bounds."""
+        h = self.make_heuristic(n_candidates=50, gauss_fraction=0.5)
+        leaf = _FakeLeaf([[2.0, 3.0], [-1.0, 0.5]], best=_FakeBest([2.9, 0.4], 1.0))
+        pts = h.sample_in_leaf(leaf)
+        assert len(pts) == 50
+        for p in pts:
+            assert (p >= leaf.box[:, 0]).all() and (p <= leaf.box[:, 1]).all()
+
+    def test_no_best_means_pure_uniform(self):
+        """Without a best point, all candidates are uniform draws in the box."""
+        h = self.make_heuristic(n_candidates=20, gauss_fraction=0.5)
+        leaf = _FakeLeaf([[0.0, 1.0], [0.0, 1.0]])
+        pts = h.sample_in_leaf(leaf)
+        assert len(pts) == 20
+        for p in pts:
+            assert (p >= 0.0).all() and (p <= 1.0).all()
+
+    def test_on_new_results_emits_into_queue(self):
+        """End-to-end handler: leaf from fake splitter -> points in output queue."""
+        h = self.make_heuristic(n_candidates=5)
+        leaf = _FakeLeaf([[0, 1], [0, 1]], results=[object()] * 3, best=_FakeBest([0.5, 0.5], 1.0))
+
+        class _FakeSplitter:
+            leafs = [leaf]
+
+        self.strategy.analyzer.side_effect = None
+        self.strategy.analyzer.return_value = _FakeSplitter()
+
+        h.on_new_results([])
+        pts = h.get_points()
+        assert len(pts) == 5
+
+    def test_on_new_results_without_splitter_falls_back(self):
+        """No Splitter analyzer -> samples the full problem box."""
+        h = self.make_heuristic(n_candidates=5)
+        self.strategy.analyzer.side_effect = Exception("no analyzer")
+
+        h.on_new_results([])
+        pts = h.get_points()
+        assert len(pts) == 5


### PR DESCRIPTION
## Summary

Adds **`RegionUCB`**, a region-allocation heuristic in the LA-MCTS / DIRECT spirit:

- Treats the `Splitter` tree's **leaves as bandit arms**; selects a leaf via a UCB1-style score — rank-based quality from the leaf's best penalty value (constraint-aware) plus `ucb_c * sqrt(log N / n_leaf)`, with empty leaves explored first.
- Samples candidates **inside the chosen box** (mix of uniform draws and Gaussian draws around the leaf's best point, clipped to the box).
- Because placement is steered by the heuristic itself, the existing strategy-level bandits (Rewarding/UCB/Thompson) handle credit assignment — **zero `StrategyBase` changes**.

Harness: new `Rewarding_RegionUCB` spec in **standard mode** = the `Rewarding_Diverse` pool + the `RegionUCB` arm, so the per-strategy score delta isolates the region-allocation effect. Deliberately not registered in quick mode: at 75 evals the Splitter yields too few leaves to matter (15-rep quick A/B was a tie), and `test_quick_strategies_unchanged` guards quick mode at 2 specs.

## Benchmark evidence (standard mode, 10 reps, seed 42, vs `Rewarding_Diverse`)

| Problem | Diverse | +RegionUCB | Δ |
|---|---|---|---|
| StyblinskiTang_2D | 0.074 | **0.376** | **+0.302** (SR 0.20→0.50) |
| Rosenbrock_2D | 0.430 | 0.263 | −0.167 |
| 5 others | tied | tied | ~0 |
| **mean** | 0.643 | 0.662 | **+0.019** |

Textbook signature: a large win on the deceptive multimodal function (region allocation escapes the wrong basin), a tax on the unimodal valley. Rosenbrock_5D median distance halved (9.64 → 4.97) though neither variant reaches tolerance.

## Background

Replaces a per-region *strategy* prototype (parked in `sketchpad/grok_per_region_bandit_strategy.py`): a strategy-level per-leaf bandit cannot steer point placement — heuristics push autonomously into their output queues and the strategy only picks whose queue to drain — and its selection/reward paths operated on different leaves. Inverting the decomposition (bandit over *regions* inside a heuristic; strategy bandit over *heuristics* as before) keeps statistics dense and composes with every existing strategy.

## Testing

- 7 new unit tests (`tests/test_heuristic_region_ucb.py`): leaf selection (empty-first, quality, exploration), in-leaf sampling bounds, fallback paths.
- Full suite: 1404 passed, 11 skipped.
- ruff + pyright clean on touched files.

## Follow-ups

- Tune `ucb_c` / `gauss_fraction` via the self-improvement catalog (the Rosenbrock tax suggests `ucb_c < 1.0` may keep the multimodal win while shrinking the loss).
- Consider a DIRECT-style volume-aware exploration term and parent-posterior inheritance on splits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)