### PR TITLE
Un-stall the AOCC codify pipeline: metric-aware routing, first aocc codify, goal contract for multi-day agent runs

### DIFF
--- a/.github/workflows/self_improve_nightly.yml
+++ b/.github/workflows/self_improve_nightly.yml
@@ -256,17 +256,41 @@ jobs:
             echo "No ledger file present ($LEDGER) — skipping summary."
           fi
 
+      - name: Regenerate codify-scan report
+        # Committed alongside the summary so the repo always carries the
+        # current actionable codify evidence — an agent (or the operator)
+        # picking up the daily routine can read
+        # planning/self_improve_codify_scan.txt without running anything.
+        # Metric-aware (2026-07-30): the scan's suppression check and the
+        # report's candidates key on the registry the selected metric
+        # actually measures (aocc → make_ioh_strategies).
+        if: always()
+        env:
+          METRIC: ${{ github.event.inputs.metric || 'aocc' }}
+        run: |
+          if [ -f "$LEDGER" ]; then
+            uv run python scripts/self_improve.py codify-scan \
+              --metric "$METRIC" \
+              --ledger "$LEDGER" \
+              > planning/self_improve_codify_scan.txt
+          else
+            echo "No ledger file present ($LEDGER) — skipping codify-scan report."
+          fi
+
       - name: Commit ledger + summary
         if: always()
         run: |
           set -euo pipefail
-          if [ -z "$(git status --porcelain "$LEDGER" planning/self_improve_summary.txt)" ]; then
+          if [ -z "$(git status --porcelain "$LEDGER" planning/self_improve_summary.txt planning/self_improve_codify_scan.txt)" ]; then
             echo "No ledger changes to commit."
             exit 0
           fi
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add "$LEDGER" planning/self_improve_summary.txt
+          if [ -f planning/self_improve_codify_scan.txt ]; then
+            git add planning/self_improve_codify_scan.txt
+          fi
           ITER="${{ github.event.inputs.iterations || '20' }}"
           MODE="${{ github.event.inputs.mode || 'quick' }}"
           METRIC="${{ github.event.inputs.metric || 'aocc' }}"
@@ -295,4 +319,5 @@ jobs:
           path: |
             ${{ env.LEDGER }}
             planning/self_improve_summary.txt
+            planning/self_improve_codify_scan.txt
           retention-days: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,12 @@ or core optimization logic.**
 Full guide: `doc/source/guide_benchmarking.rst`. Self-improvement plan:
 `planning/SELF_IMPROVEMENT_LOOP.md`.
 
+**Goal contract for autonomous / multi-day improvement work:**
+`planning/GOAL.md` — read it first when the instruction is an open-ended
+"improve panobbgo". It defines the metric of record (AOCC on the
+MA-BBOB battery), the per-session operating loop, the multi-day
+escalation ladder, and the SOTA-informed research backlog.
+
 ### Workflow
 
 ```bash
@@ -1048,6 +1054,29 @@ The harness is the measurement substrate for an autonomous
     the CLI resolves the path.  See the 2026-07-09 entry in
     `planning/SELF_IMPROVEMENT_LOG.md`.
 
+*   **2026-07-30 — metric-aware codify routing (registries + apply
+    sources)** — closes the aocc-era codify last mile.  Between the
+    2026-07-09 metric flip and this ship, the nightly loop measured
+    :func:`panobbgo.harness_ioh.make_ioh_strategies` but
+    `default_codify_registries()` (suppression) and
+    `default_codify_apply_sources()` (the `--apply-top` edit driver)
+    still pointed exclusively at the composite factories in
+    `panobbgo/harness.py` — so aocc evidence (which names IOH specs
+    like `Rewarding_Restart`) could never land as a source edit: the
+    driver scanned the wrong file, found no matching spec, and
+    silently no-oped while the bandit re-discovered the same wins
+    every night (the `drop_analyzer Restart` candidate accumulated 18
+    confirmed accepts across 17 nights this way).  Both functions now
+    take `metric: str = "composite"`; `"aocc"` routes to
+    `make_ioh_strategies` / `panobbgo/harness_ioh.py`, and
+    `codify-scan` threads its `--metric` selector into both.  The
+    same change banked the first aocc codify (dropped the `Restart`
+    analyzer from `Rewarding_Restart`; local quick-battery A/B
+    `0.3538 → 0.3922`) and added a nightly-committed
+    `planning/self_improve_codify_scan.txt` report so the current
+    actionable evidence is readable without running anything.  The
+    goal contract for agent-driven sessions lives in
+    `planning/GOAL.md` (shipped in the same change).
 *   **2026-07-10 — per-metric ledger routing (`--metric` selector +
     metric-scoped archive pooling)** — closes the first two AOCC-regime
     follow-ups the 2026-07-09 flip left open.  (1) `run` / `summary` /

--- a/TODO.md
+++ b/TODO.md
@@ -27,9 +27,16 @@
       `AGENTS.md`.
 - [x] **Validation** — 6 new tests (`TestMetricAwareCodifyRouting`); full
       `tests/test_self_improve.py` suite green (611 passed); ruff clean.
-- [ ] **Queued codify slots (one PR each, re-measure between)** —
-      `drop_heuristic Sobol` (3 nights), `add_heuristic LBFGSB` (3 nights),
-      `drop_heuristic Center` (2 nights), `Sobol.n 32 → 38` (2 nights).
+- [x] **Queued codify slots worked through (2026-07-30 second session)** —
+      `drop_heuristic Sobol` ACCEPTED (standard battery +0.0176, spec now
+      beats random at both dims); `add_heuristic LBFGSB` REJECTED (−0.0146
+      on the post-Sobol-drop spec — interaction negative); `drop_heuristic
+      Center` REJECTED (−0.0229; Center is load-bearing without Sobol);
+      `Sobol.n 32 → 38` moot.  Structural-add driver hardened in the same
+      session: missing-comma fix, `structural_kwargs` carried into edits,
+      factory-import rewriting, parse-validation net in
+      `apply_codify_edits` (8 new tests).  See the log's second 2026-07-30
+      entry.
 - [ ] **Open weakness** — hold-out base seeds score far below training seed
       (0.04 vs 0.33 on 2026-07-30): instance-family generalization is the
       top research target (see `planning/GOAL.md` §5).

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,38 @@
 
 ## Recent Improvements (continued)
 
+### Metric-aware codify routing + first aocc codify + goal contract — 2026-07-30
+- [x] **Bug fix (the aocc codify stall)** — `default_codify_registries()` and
+      `default_codify_apply_sources()` in `panobbgo/self_improve.py` gain a
+      `metric: str = "composite"` parameter; `"aocc"` routes suppression to
+      `panobbgo.harness_ioh.make_ioh_strategies` and the `--apply-top` edit
+      driver to `panobbgo/harness_ioh.py`.  Between 2026-07-09 (nightly metric
+      flip) and this fix, aocc evidence could never land as a source edit —
+      the driver scanned `harness.py`, found no matching spec, and silently
+      no-oped while the bandit re-discovered the same wins nightly (18
+      confirmed `drop_analyzer Restart` accepts across 17 nights).
+      `codify-scan` threads `--metric` into both call sites.
+- [x] **First aocc codify banked** — dropped the `Restart` analyzer from the
+      `Rewarding_Restart` spec in `make_ioh_strategies` via the fixed driver.
+      Local paired A/B (quick IOH battery): `Rewarding_Restart` mean AOCC
+      `0.3538 → 0.3922`, `RoundRobin_Random` control flat.  Post-codify scan
+      auto-suppresses the candidate (self-stability verified).
+- [x] **Nightly visibility** — `self_improve_nightly.yml` now regenerates and
+      commits `planning/self_improve_codify_scan.txt` (metric-aware) alongside
+      the summary, so actionable evidence is readable without running anything.
+- [x] **Goal contract** — new `planning/GOAL.md`: metric of record, per-session
+      operating loop, multi-day escalation ladder, SOTA-informed research
+      backlog (MA-BBOB / LLaMEA / modular CMA-ES context).  Pointer added to
+      `AGENTS.md`.
+- [x] **Validation** — 6 new tests (`TestMetricAwareCodifyRouting`); full
+      `tests/test_self_improve.py` suite green (611 passed); ruff clean.
+- [ ] **Queued codify slots (one PR each, re-measure between)** —
+      `drop_heuristic Sobol` (3 nights), `add_heuristic LBFGSB` (3 nights),
+      `drop_heuristic Center` (2 nights), `Sobol.n 32 → 38` (2 nights).
+- [ ] **Open weakness** — hold-out base seeds score far below training seed
+      (0.04 vs 0.33 on 2026-07-30): instance-family generalization is the
+      top research target (see `planning/GOAL.md` §5).
+
 ### Opt-in higher-dimensional battery (`extra_families` / `--extra-highdim`) — 2026-07-13
 - [x] **Measurement substrate** — added
       `panobbgo/harness_randomized.py::make_highdim_families` (a rotated

--- a/panobbgo/harness_ioh.py
+++ b/panobbgo/harness_ioh.py
@@ -338,7 +338,7 @@ def make_ioh_strategies() -> List[StrategySpec]:
     :func:`panobbgo.harness_baselines.make_baseline_strategies` if you
     need an absolute reference.
     """
-    from panobbgo.analyzers import Restart, Sensitivity
+    from panobbgo.analyzers import Sensitivity
     from panobbgo.heuristics import Center, Nearby, NelderMead, Random, Sobol
     from panobbgo.strategies import StrategyRewarding, StrategyRoundRobin
 
@@ -352,12 +352,16 @@ def make_ioh_strategies() -> List[StrategySpec]:
             strategy_class=StrategyRoundRobin,
             heuristics=[(Random, {})],
         ),
-        # Adaptive heuristic mix + Restart-on-stagnation.  This is the
-        # working candidate for the MA-BBOB competition entry: roughly
-        # the same heuristics as ``Rewarding_Diverse`` from the
-        # composite-score harness, but with the Restart analyzer wired
-        # in so the second half of the budget is spent jumping basins
-        # rather than refining the same flat tail.
+        # Adaptive heuristic mix.  This is the working candidate for the
+        # MA-BBOB competition entry: roughly the same heuristics as
+        # ``Rewarding_Diverse`` from the composite-score harness.  The
+        # Restart analyzer it originally shipped with was dropped by the
+        # 2026-07-30 codify (18 confirmed drop_analyzer accepts across 17
+        # distinct nights on the aocc ledger, pooled CI95%
+        # [+0.0084, +0.0147]) — under the anytime AOCC metric the
+        # diverse-restart jumps cost more mid-budget precision than the
+        # basin-hopping recovers.  The spec name is kept for ledger /
+        # bandit-arm continuity.
         StrategySpec(
             name="Rewarding_Restart",
             strategy_class=StrategyRewarding,
@@ -370,12 +374,6 @@ def make_ioh_strategies() -> List[StrategySpec]:
             ],
             analyzers=[
                 (Sensitivity, {"update_interval": 25}),
-                # patience tuned to give the Sobol sweep + a generous
-                # local refinement phase before declaring stagnation.
-                # 5*dim is the Restart default; we go higher to bias
-                # toward exploitation early and only restart when we are
-                # genuinely stuck.
-                (Restart, {"patience": None, "improvement_threshold": 1e-6, "restart_strategy": "diverse"}),
             ],
         ),
     ]

--- a/panobbgo/harness_ioh.py
+++ b/panobbgo/harness_ioh.py
@@ -339,7 +339,7 @@ def make_ioh_strategies() -> List[StrategySpec]:
     need an absolute reference.
     """
     from panobbgo.analyzers import Sensitivity
-    from panobbgo.heuristics import Center, Nearby, NelderMead, Random, Sobol
+    from panobbgo.heuristics import Center, Nearby, NelderMead, Random
     from panobbgo.strategies import StrategyRewarding, StrategyRoundRobin
 
     return [

--- a/panobbgo/harness_ioh.py
+++ b/panobbgo/harness_ioh.py
@@ -366,7 +366,6 @@ def make_ioh_strategies() -> List[StrategySpec]:
             name="Rewarding_Restart",
             strategy_class=StrategyRewarding,
             heuristics=[
-                (Sobol, {"n": 32, "scramble": True}),
                 (Random, {}),
                 (Nearby, {"radius": 0.1, "axes": "all", "new": 3}),
                 (Center, {}),

--- a/panobbgo/self_improve.py
+++ b/panobbgo/self_improve.py
@@ -6047,16 +6047,27 @@ def _structural_already_codified(
     return False
 
 
-def default_codify_registries() -> List[Callable[[], List[StrategySpec]]]:
+def default_codify_registries(
+    metric: str = "composite",
+) -> List[Callable[[], List[StrategySpec]]]:
     """Default seed-spec factories the codify-scan suppression check uses.
 
-    Returns the two factories the V2 nightly cron exercises — the
-    ``quick`` registry (the default mode) and the ``loop`` registry
-    (the catalog-exercising registry shipped 2026-06-10).  The
-    ``loop`` registry already includes the ``quick`` specs, but
-    listing both makes the predicate behaviour the same whether the
-    nightly is currently configured to ``--registry quick`` or
-    ``--registry loop``.
+    The factories depend on which metric's ledger is being scanned,
+    because each metric measures a different seed registry:
+
+    * ``"composite"`` — the two factories the composite cron exercises:
+      the ``quick`` registry (the historical default mode) and the
+      ``loop`` registry (the catalog-exercising registry shipped
+      2026-06-10).  The ``loop`` registry already includes the
+      ``quick`` specs, but listing both makes the predicate behaviour
+      the same whether the run was configured with ``--registry
+      quick`` or ``--registry loop``.
+    * ``"aocc"`` — :func:`panobbgo.harness_ioh.make_ioh_strategies`,
+      the IOH-tuned registry every ``--metric aocc`` iteration
+      measures (the nightly default since 2026-07-09).  Checking the
+      composite registries here would compare candidates against specs
+      the aocc loop never runs, so suppression would key on the wrong
+      source of truth.
 
     Standard / full registries are intentionally excluded: their seed
     specs target the manual benchmark battery (200 / 500 evals), not
@@ -6064,6 +6075,10 @@ def default_codify_registries() -> List[Callable[[], List[StrategySpec]]]:
     codification only lives in those registries would mis-direct the
     operator away from actionable evidence on the cron's regime.
     """
+    if metric == "aocc":
+        from panobbgo.harness_ioh import make_ioh_strategies
+
+        return [make_ioh_strategies]
     from panobbgo.harness import _make_loop_strategies, _make_quick_strategies
 
     return [_make_quick_strategies, _make_loop_strategies]
@@ -6147,8 +6162,21 @@ _DEFAULT_APPLY_SOURCES: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
     ),
 )
 
+# The aocc regime measures the IOH-tuned registry, so its codify edits
+# must land in panobbgo/harness_ioh.py — the composite factories above
+# never run under --metric aocc and editing them from aocc evidence
+# would cross-contaminate the two ~100×-different delta scales.
+_DEFAULT_APPLY_SOURCES_AOCC: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
+    (
+        "panobbgo/harness_ioh.py",
+        ("make_ioh_strategies",),
+    ),
+)
 
-def default_codify_apply_sources() -> List[Tuple[str, Tuple[str, ...]]]:
+
+def default_codify_apply_sources(
+    metric: str = "composite",
+) -> List[Tuple[str, Tuple[str, ...]]]:
     """Source files + factory function names the ``--apply-top`` driver scans.
 
     Returns ``[(source_path, (factory_name, ...))]``.  Each ``source_path``
@@ -6160,18 +6188,30 @@ def default_codify_apply_sources() -> List[Tuple[str, Tuple[str, ...]]]:
     value, ...})`` heuristic / analyzer entry that the codify candidate
     targets.
 
-    Broader than :func:`default_codify_registries` (which returns only
-    the ``quick`` + ``loop`` registries, the regime the nightly cron
-    measures): the apply driver covers ``standard`` / ``full`` too so a
-    single codify run updates every sibling spec sharing the same
-    heuristic mix.  This matches the 2026-06-28 manual codify pattern
-    (``Nearby.radius = 0.124`` across ``Rewarding_Diverse`` plus five
-    sibling specs across all four registry tiers in one PR).
+    The source set depends on which metric's evidence is being applied,
+    mirroring :func:`default_codify_registries`:
+
+    * ``"composite"`` — ``panobbgo/harness.py``, all four registry
+      tiers.  Broader than :func:`default_codify_registries` (which
+      returns only the ``quick`` + ``loop`` registries, the regime the
+      nightly cron measures): the apply driver covers ``standard`` /
+      ``full`` too so a single codify run updates every sibling spec
+      sharing the same heuristic mix.  This matches the 2026-06-28
+      manual codify pattern (``Nearby.radius = 0.124`` across
+      ``Rewarding_Diverse`` plus five sibling specs across all four
+      registry tiers in one PR).
+    * ``"aocc"`` — ``panobbgo/harness_ioh.py``'s
+      ``make_ioh_strategies``, the registry every ``--metric aocc``
+      iteration measures.  Without this routing, aocc evidence (which
+      names IOH specs like ``Rewarding_Restart``) can never land as a
+      source edit — the ``--apply-top`` driver would scan
+      ``harness.py``, find no matching spec, and silently no-op.
 
     Returns a fresh ``list`` so callers can mutate without affecting the
     module-level constant.
     """
-    return [(path, names) for (path, names) in _DEFAULT_APPLY_SOURCES]
+    table = _DEFAULT_APPLY_SOURCES_AOCC if metric == "aocc" else _DEFAULT_APPLY_SOURCES
+    return [(path, names) for (path, names) in table]
 
 
 def _format_value_repr(value: Any) -> str:

--- a/panobbgo/self_improve.py
+++ b/panobbgo/self_improve.py
@@ -162,6 +162,7 @@ import bisect
 import json
 import math
 import pathlib
+import sys
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -5490,6 +5491,13 @@ class CodifyCandidate:
     confirmed_flags: Tuple[Optional[bool], ...]
     already_codified: bool = False
     live_codified_values: Tuple[Any, ...] = ()
+    #: Per-record ``proposal.structural_kwargs`` (dict or ``None``) in
+    #: ledger order.  Only meaningful for structural ``add_*`` ops —
+    #: the kwargs the measured arm constructed the added class with
+    #: (e.g. ``{"warm_start": True}`` for the LBFGSB catalog
+    #: candidate).  Kwarg / categorical candidates carry an empty
+    #: tuple.  Consumed by :meth:`consensus_structural_kwargs`.
+    structural_kwargs_list: Tuple[Optional[Dict[str, Any]], ...] = ()
 
     @property
     def n_distinct_nights(self) -> int:
@@ -5544,6 +5552,33 @@ class CodifyCandidate:
         treat the result as suggestive only.
         """
         return _percentile_bootstrap_ci(self.deltas, n_boot=n_boot, confidence=confidence, seed=seed)
+
+    def consensus_structural_kwargs(self) -> Optional[Dict[str, Any]]:
+        """Kwargs a structural ``add_*`` codify edit should construct with.
+
+        The nightly loop measured the added class with the *catalog
+        candidate's* kwargs (recorded per-accept in
+        ``proposal.structural_kwargs``), so a codify edit that writes
+        ``(Class, {})`` would ship something the ledger never measured
+        — for ``LBFGSB`` the difference is stark: the catalog arm is
+        ``{"warm_start": True}`` precisely because the cold variant was
+        a measured regression (2026-07-06 negative result).
+
+        Returns the most common kwargs dict among contributing records
+        (ties broken toward the most recent), or ``None`` when no
+        record carries kwargs (legacy ledgers, drop ops, kwarg rules).
+        """
+        counted: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
+        for idx, kw in enumerate(self.structural_kwargs_list):
+            if not isinstance(kw, dict):
+                continue
+            key = json.dumps({k: kw[k] for k in sorted(kw)}, sort_keys=True, default=str)
+            count, _last_idx, _ = counted.get(key, (0, -1, kw))
+            counted[key] = (count + 1, idx, kw)
+        if not counted:
+            return None
+        _, _, best = max(counted.values(), key=lambda t: (t[0], t[1]))
+        return dict(best)
 
     def proposed_codify_value(self, *, n_sig: int = 3) -> Any:
         """Compute the new seed value a codify edit would apply for this candidate.
@@ -5641,6 +5676,7 @@ class CodifyCandidate:
             "already_codified": bool(self.already_codified),
             "live_codified_values": [_to_plain(v) for v in self.live_codified_values],
             "proposed_codify_value": _to_plain(self.proposed_codify_value()),
+            "structural_kwargs": self.consensus_structural_kwargs(),
         }
 
 
@@ -5739,6 +5775,7 @@ def aggregate_codify_candidates(
                 "timestamps": [],
                 "strategy_names": [],
                 "confirmed_flags": [],
+                "structural_kwargs_list": [],
                 "dates": set(),
             },
         )
@@ -5749,6 +5786,8 @@ def aggregate_codify_candidates(
         bucket["new_values"].append(proposal.get("new_value"))
         bucket["timestamps"].append(str(rec.get("timestamp", "")))
         bucket["strategy_names"].append(str(proposal.get("strategy_name", "")))
+        skw = proposal.get("structural_kwargs")
+        bucket["structural_kwargs_list"].append(dict(skw) if isinstance(skw, dict) else None)
         confirmed = rec.get("confirmed")
         bucket["confirmed_flags"].append(None if confirmed is None else bool(confirmed))
         date_str = _date_from_timestamp(rec.get("timestamp"))
@@ -5779,6 +5818,7 @@ def aggregate_codify_candidates(
             timestamps=tuple(data["timestamps"]),
             strategy_names=tuple(data["strategy_names"]),
             confirmed_flags=tuple(data["confirmed_flags"]),
+            structural_kwargs_list=tuple(data["structural_kwargs_list"]),
         )
         candidates.append(cand)
 
@@ -6571,6 +6611,89 @@ def _byte_to_lineno_col(byte_offset: int, line_starts: Sequence[int]) -> Tuple[i
     return lineno, col_offset
 
 
+def _format_structural_kwargs(kwargs: Optional[Dict[str, Any]]) -> str:
+    """Render an ``add_*`` entry's kwargs dict as project-style source.
+
+    Double-quoted keys + :func:`_format_value_repr` values, insertion
+    order preserved — matches the ``(ClassName, {"param": value})``
+    convention used across the seed-spec factories.  ``None`` / empty
+    renders as ``{}`` (constructor defaults).
+    """
+    if not kwargs:
+        return "{}"
+    inner = ", ".join(f'"{k}": {_format_value_repr(v)}' for k, v in kwargs.items())
+    return "{" + inner + "}"
+
+
+_STRUCTURAL_BUCKET_TO_IMPORT_MODULE: Dict[str, str] = {
+    "heuristics": "panobbgo.heuristics",
+    "analyzers": "panobbgo.analyzers",
+}
+
+
+def _derive_import_edit(
+    text: str,
+    line_starts: List[int],
+    factory: ast.FunctionDef,
+    *,
+    module: str,
+    class_name: str,
+    source_path: str,
+    op: str,
+) -> Optional[CodifyEdit]:
+    """Rewrite the factory's ``from <module> import ...`` to bind ``class_name``.
+
+    Seed-spec factories import their heuristic / analyzer classes
+    inside the function body (e.g. ``from panobbgo.heuristics import
+    Center, Random``), so a structural ``add_*`` entry edit for a class
+    the factory has never used would raise ``NameError`` at run time.
+    This helper finds the factory's matching :class:`ast.ImportFrom`
+    and produces a :class:`CodifyEdit` replacing it with the same
+    import plus ``class_name`` inserted in sorted position (aliases are
+    preserved verbatim).
+
+    Returns ``None`` when the class is already bound by the import,
+    or when the factory contains no import from ``module`` — in the
+    latter case the caller ships the entry edit alone and the operator
+    resolves the binding manually (the post-apply parse validation in
+    :func:`apply_codify_edits` only guards *syntax*, not name
+    resolution).
+    """
+    for node in ast.walk(factory):
+        if not isinstance(node, ast.ImportFrom) or node.module != module:
+            continue
+        if any(alias.name == class_name for alias in node.names):
+            return None
+        if node.end_lineno is None or node.end_col_offset is None:
+            return None
+        rendered = [
+            (alias.name, f"{alias.name} as {alias.asname}" if alias.asname else alias.name) for alias in node.names
+        ]
+        rendered.append((class_name, class_name))
+        rendered.sort(key=lambda pair: pair[0])
+        new_source = f"from {module} import " + ", ".join(src for _name, src in rendered)
+        start_byte = line_starts[node.lineno - 1] + node.col_offset
+        end_byte = line_starts[node.end_lineno - 1] + node.end_col_offset
+        return CodifyEdit(
+            source_path=source_path,
+            factory_name=factory.name,
+            spec_name="<import>",
+            class_name=class_name,
+            param_name="",
+            rule_kind="structural",
+            direction=op,
+            old_value=None,
+            new_value=None,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            end_lineno=node.end_lineno,
+            end_col_offset=node.end_col_offset,
+            old_source=text[start_byte:end_byte],
+            new_source=new_source,
+        )
+    return None
+
+
 def _scan_source_for_structural_edits(
     source_path: str,
     *,
@@ -6578,6 +6701,7 @@ def _scan_source_for_structural_edits(
     class_name: str,
     op: str,
     target_spec_names: Optional[Set[str]] = None,
+    add_kwargs: Optional[Dict[str, Any]] = None,
 ) -> List[CodifyEdit]:
     """Find every :class:`StrategySpec` site to structurally mutate for ``class_name``.
 
@@ -6598,12 +6722,23 @@ def _scan_source_for_structural_edits(
     * ``add_heuristic`` / ``add_analyzer``: emit a single zero-width
       insertion :class:`CodifyEdit` at the position just *before* the
       closing ``]`` of the target bucket.  The inserted text is
-      ``(ClassName, {}),\\n<indent>`` where ``<indent>`` matches the
-      column offset of the bucket's first existing entry (falling back
-      to 12 spaces — the ``StrategySpec(...)`` convention used across
-      ``_make_*_strategies``).  The empty dict signals "use constructor
-      defaults"; operators tune the added heuristic via the standard
-      kwarg-mutation catalog after the add.
+      ``(ClassName, <kwargs>),\\n<indent>`` where ``<indent>`` matches
+      the column offset of the bucket's first existing entry (falling
+      back to 12 spaces — the ``StrategySpec(...)`` convention used
+      across ``_make_*_strategies``) and ``<kwargs>`` renders
+      ``add_kwargs`` via :func:`_format_structural_kwargs` (``{}`` =
+      constructor defaults when the candidate carries none).  When the
+      last existing entry has no trailing comma (compact single-line
+      buckets like ``heuristics=[(Random, {})]``), a ``,`` is inserted
+      first so the resulting list literal stays syntactically valid.
+      When ``class_name`` is not already bound by the factory's
+      ``from panobbgo.heuristics import ...`` (or ``.analyzers``)
+      statement, an additional :class:`CodifyEdit` rewrites that import
+      with the class inserted in sorted position — one import edit per
+      (factory, module) even when several specs in the factory receive
+      the class.  A factory with no matching import statement gets no
+      import edit (the entry edit still lands; the operator resolves
+      the binding manually).
 
     Safety guards keep the primitive conservative:
 
@@ -6658,6 +6793,7 @@ def _scan_source_for_structural_edits(
     except SyntaxError:
         return []
     edits: List[CodifyEdit] = []
+    import_edited: Set[Tuple[str, str]] = set()
     factory_set = set(factory_names)
     # Precompute line starts for byte-offset arithmetic — matches the
     # convention in :func:`_apply_edits_to_text` so the resulting
@@ -6825,6 +6961,7 @@ def _scan_source_for_structural_edits(
                 #
                 # Both variants preserve the source's existing
                 # indentation convention rather than guessing.
+                kwargs_source = _format_structural_kwargs(add_kwargs)
                 if bucket.elts:
                     last_entry = bucket.elts[-1]
                     if last_entry.end_lineno is None or last_entry.end_col_offset is None:
@@ -6833,16 +6970,25 @@ def _scan_source_for_structural_edits(
                     if last_end < 0 or last_end > len(text):
                         continue
                     # Consume a trailing comma if present so the new
-                    # entry lands after it (not before).
+                    # entry lands after it (not before).  When the last
+                    # entry has NO trailing comma (compact single-line
+                    # buckets like ``heuristics=[(Random, {})]``), the
+                    # insertion must supply one itself — inserting the
+                    # new tuple directly after ``(Random, {})`` would
+                    # produce the *call expression* ``(Random,
+                    # {})(NewClass, {})``, which is syntactically valid
+                    # to the eye but crashes at import time.
                     insert_byte = last_end
-                    if insert_byte < len(text) and text[insert_byte] == ",":
+                    had_trailing_comma = insert_byte < len(text) and text[insert_byte] == ","
+                    if had_trailing_comma:
                         insert_byte += 1
                     # Match the last entry's indent (its column offset
                     # is the number of leading spaces before it on its
                     # line) so the new entry aligns visually.
                     indent = " " * last_entry.col_offset
                     insert_lineno, insert_col = _byte_to_lineno_col(insert_byte, line_starts)
-                    new_entry_source = f"\n{indent}({class_name}, {{}}),"
+                    comma_prefix = "" if had_trailing_comma else ","
+                    new_entry_source = f"{comma_prefix}\n{indent}({class_name}, {kwargs_source}),"
                 else:
                     # Empty bucket (e.g. ``analyzers=[]``): insert
                     # inline between ``[`` and ``]`` since there's no
@@ -6855,7 +7001,7 @@ def _scan_source_for_structural_edits(
                         continue
                     insert_byte = open_byte
                     insert_lineno, insert_col = _byte_to_lineno_col(insert_byte, line_starts)
-                    new_entry_source = f"({class_name}, {{}})"
+                    new_entry_source = f"({class_name}, {kwargs_source})"
                 edits.append(
                     CodifyEdit(
                         source_path=source_path,
@@ -6875,6 +7021,24 @@ def _scan_source_for_structural_edits(
                         new_source=new_entry_source,
                     )
                 )
+                # Make sure the factory can actually resolve the class
+                # it now constructs — one import rewrite per (factory,
+                # module) even when several specs in the factory
+                # receive the class.
+                module = _STRUCTURAL_BUCKET_TO_IMPORT_MODULE.get(bucket_name)
+                if module is not None and (top.name, module) not in import_edited:
+                    import_edit = _derive_import_edit(
+                        text,
+                        line_starts,
+                        top,
+                        module=module,
+                        class_name=class_name,
+                        source_path=source_path,
+                        op=op,
+                    )
+                    import_edited.add((top.name, module))
+                    if import_edit is not None:
+                        edits.append(import_edit)
     return edits
 
 
@@ -6944,6 +7108,7 @@ def derive_codify_edits(
                     class_name=candidate.class_name,
                     op=candidate.op,
                     target_spec_names=target_spec_names,
+                    add_kwargs=candidate.consensus_structural_kwargs(),
                 )
             )
         return edits
@@ -7041,6 +7206,22 @@ def apply_codify_edits(
             continue
         text = path.read_text()
         new_text = _apply_edits_to_text(text, file_edits)
+        # Safety net: never land a syntactically-broken source file.  A
+        # coordinate bug in an edit primitive (e.g. the pre-2026-07-30
+        # missing-comma insertion on single-line buckets) must surface
+        # as a loud skip, not a silently corrupted registry that every
+        # later harness run crashes on.
+        if source_path.endswith(".py"):
+            try:
+                ast.parse(new_text)
+            except SyntaxError as exc:
+                print(
+                    f"apply_codify_edits: refusing to write {source_path} — "
+                    f"edited result does not parse ({exc}).  "
+                    "This is a bug in the edit primitive; nothing was written.",
+                    file=sys.stderr,
+                )
+                continue
         out[source_path] = new_text
         if not dry_run and new_text != text:
             path.write_text(new_text)

--- a/planning/GOAL.md
+++ b/planning/GOAL.md
@@ -1,0 +1,197 @@
+# GOAL — Converge on a world-class black-box optimizer
+
+**Audience**: any agent (or human) picking up this repository with the standing
+instruction "improve panobbgo". This file is the durable goal contract; read it
+first, then act through the operating loop below. Everything referenced here
+already exists and is tested — no setup beyond `uv sync --extra dev` and
+`cd tools/ioh_worker && uv sync`.
+
+---
+
+## 1. North star (the measurable goal)
+
+Maximize **mean AOCC** (Area Over the Convergence Curve, the IOHprofiler /
+MA-BBOB Anytime competition metric) of the best panobbgo strategy on the
+MA-BBOB battery, at competition-style budgets, without regressing the frozen
+`composite_score` contract on the internal battery.
+
+Concretely, in priority order:
+
+1. **Beat the internal floor**: `Rewarding_Restart` (the competition candidate
+   spec in `panobbgo/harness_ioh.py::make_ioh_strategies`) must dominate
+   `RoundRobin_Random` on every battery tier (quick / standard / full).
+2. **Beat the external baselines**: `Baseline_SciPyDE` and
+   `Baseline_SciPyAnneal` (`panobbgo/harness_baselines.py`) on mean AOCC at
+   the standard battery. Random search is the hard floor — never lose to it.
+3. **Approach competition level**: the MA-BBOB Anytime competition regime is
+   budget `2000·d`, dims 2 and 5, ~1000 affine instances. World-class 2024/2025
+   entries were LLaMEA-generated hybrids (LLM-designed metaheuristics — i.e.
+   structurally the same loop this repo runs on itself). The long-run target is
+   a strategy competitive with tuned modular CMA-ES / L-SHADE-lineage hybrids
+   with warm-started local search at that regime.
+
+**Metric of record**: mean AOCC from `scripts/ioh_benchmark.py` /
+`--metric aocc` self-improvement runs. `composite_score` is the frozen
+legacy contract — keep it green, don't optimize for it.
+
+## 2. State snapshot (2026-07-30 — update when it materially changes)
+
+* Nightly cron (`self_improve_nightly.yml`, 03:00 UTC) runs 20 mutation
+  iterations on `--metric aocc`, quick IOH battery, with confirmation gate,
+  guard, multi-seed hold-out; appends to
+  `planning/self_improve_ledger_aocc.jsonl` and commits summary + codify-scan
+  reports.
+* Seed score plateau: quick-battery mean AOCC ≈ 0.33–0.36 for weeks — the
+  loop found improvements nightly but the codify last-mile was broken for the
+  aocc regime until 2026-07-30 (metric-aware routing fix + first aocc codify:
+  dropped the `Restart` analyzer from `Rewarding_Restart`, 17 nights of
+  evidence, local A/B `0.3538 → 0.3922`).
+* Known competitive gap: hold-out base seeds (7, 1234) score far below the
+  training seed (0.04 vs 0.33 on 2026-07-30) — instance-family sensitivity
+  is the biggest open weakness. Higher-dim (5-D) rotated valleys are the
+  second (see `--extra-highdim` and the 2026-07-06..13 log entries).
+
+## 3. Operating loop (one agent session ≈ one iteration)
+
+Run this every session; it is deliberately mechanical. The nightly cron
+produces evidence while you're away — your job is to bank it and then push the
+frontier.
+
+```bash
+# 0. Sync + sanity (both venvs; IOH tests skip without the worker venv)
+uv sync --extra dev && (cd tools/ioh_worker && uv sync)
+
+# 1. Read the overnight state (committed nightly by the cron)
+cat planning/self_improve_summary.txt          # trend, bandit posteriors
+cat planning/self_improve_codify_scan.txt      # actionable evidence
+
+# 2. Bank the evidence: apply the top cross-night candidate
+uv run python scripts/self_improve.py codify-scan --metric aocc \
+    --apply-top --apply-dry-run                # inspect first
+uv run python scripts/self_improve.py codify-scan --metric aocc \
+    --apply-top --apply-format --apply-run-tests
+
+# 3. Verify with a local A/B on the metric of record
+uv run python scripts/ioh_benchmark.py run --quick --output /tmp/before.json   # on master
+#   ...apply change...
+uv run python scripts/ioh_benchmark.py run --quick --output /tmp/after.json
+uv run python scripts/ioh_benchmark.py compare /tmp/before.json /tmp/after.json
+
+# 4. Full gate before PR
+uv run pytest -q && uv run ruff check && uv run ruff format --check
+
+# 5. One PR per change, evidence in the body (see AGENTS.md
+#    "Agent-driven improve X PRs" for the evidence-form rules).
+```
+
+Before opening a PR, check open PRs for duplicates (the nightly branches from
+master and cannot see unmerged work).
+
+## 4. Multi-day convergence protocol
+
+A multi-day run is the loop above plus an escalation ladder. Each day:
+
+1. **Bank** (steps 1–5 above) — codify accumulated ledger evidence. This is
+   always first: unbanked evidence is re-discovered and wasted every night.
+2. **Diagnose** — find the sharpest measured gap. Sources, in order:
+   hold-out drift records (instance-family generalization), per-problem AOCC
+   breakdown from a `--standard` run, `--extra-highdim` families, the
+   baseline comparison (`--baselines`).
+3. **Attack one gap** with a *measured* algorithmic change (new heuristic
+   kwarg, warm-start, schedule, or structural mix). The 2026-07-05..12 log
+   entries (NP_init="auto", warm-started L-BFGS-B, quadratic Nearby) are the
+   template: isolate the mechanism, measure at the dimension/regime where the
+   effect lives, ship §7.3-freeze-compliant.
+4. **Widen the evidence base** when the quick battery saturates: promote
+   validation runs to `--standard` (locally or via `workflow_dispatch` with
+   `mode=standard`), and check the plain-BBOB / higher-dim regimes so gains
+   aren't MA-BBOB-quick-battery overfit.
+5. **Log** — dated entry in `planning/SELF_IMPROVEMENT_LOG.md` (what was
+   measured, what shipped, next ideas). The log is the loop's long-term
+   memory; unlogged negative results get retried by future sessions.
+
+Cadence guardrails:
+
+* Never ship an optimizer-behavior change without a paired A/B on the metric
+  of record (nightly ledger evidence counts; see AGENTS.md evidence forms).
+* One codify slot per PR. Independent evidence ≠ joint evidence — don't batch
+  three "individually positive" drops into one unmeasured combination.
+* The composite-score formula and the default randomized battery are frozen
+  contracts. Extend via opt-in flags (`--extra-highdim` pattern), never edit.
+* If the quick-battery score stalls for >1 week with evidence banked, the
+  bottleneck is the *measurement regime*, not the mutations — move up the
+  ladder (standard battery, more instances, higher dims) before inventing
+  new mutations.
+
+## 5. Research backlog (SOTA-informed, 2026-07)
+
+Ordered by expected value; each item should enter through the loop above.
+
+1. **Instance-family generalization** — close the training-seed vs hold-out
+   gap (0.33 vs 0.04). Suspects: Sobol-heavy initial design overfit to the
+   training instances' scale; missing restart diversity after the Restart
+   analyzer drop. Measure per-instance AOCC spread first.
+2. **CMA-ES arm** — the strongest classical family at this regime is modular
+   CMA-ES; panobbgo has no covariance-adapting heuristic. A minimal
+   `CMAES` heuristic (pycma or hand-rolled (μ/μ_w, λ)-ES) as a structural
+   catalog candidate would let the bandit measure it against the DE family.
+3. **Rank-based acceptance stats** — mean-AOCC deltas are outlier-sensitive;
+   competition practice is Wilcoxon / Friedman over (function, instance)
+   pairs. Add as an alternative `statistical_accept` mode.
+4. **Plain-BBOB cross-validation battery** — 24 BBOB functions, dims
+   {2, 3, 5, 10}, as an opt-in hold-out suite (the `ioh` package already
+   provides them through the same worker protocol).
+5. **Anytime-aware strategy scheduling** — AOCC rewards early descent;
+   panobbgo's rewarding strategy re-weights on "new best" events only.
+   Explore time-decayed rewards / explicit budget-phase schedules.
+6. **Behavior-space diagnostics** (LLaMEA-SAGE direction) — log per-run
+   trajectory features (dispersion, basin-jump counts) into the ledger so
+   codify-scan can correlate *why* an arm wins, not just that it does.
+7. **Learned "intuition layer" (Dynamic Algorithm Configuration)** — a small
+   dense policy network that watches run-time progress and re-weights /
+   switches heuristics mid-run.  `StrategyRewarding`'s bandit is the
+   memoryless special case; the generalization is a stateful policy:
+
+   * **Observations** (per batch of results): budget fraction consumed,
+     best-so-far improvement rate over the last k batches, stagnation
+     length, per-heuristic reward distribution, point-cloud dispersion,
+     Splitter depth stats — cheap features already derivable from the
+     eventbus (`on_new_results` / `on_new_best`).
+   * **Action**: a weight vector over the active heuristics (drop-in for
+     the rewarding strategy's bandit weights), optionally a restart /
+     phase-switch signal.
+   * **Training**: evolution strategies (CMA-ES / OpenAI-ES) over the
+     policy weights — no backprop through the optimization run needed.
+     Fitness = mean AOCC over a stratified batch of randomized instances
+     (`harness_randomized` families / MA-BBOB instances); hold-out
+     base seeds catch policy overfit exactly as they do for the mutation
+     loop.  A few thousand policy evaluations × quick-battery cost is
+     feasible on the existing parallel harness.
+   * **Deliverable path**: (a) feature extractor as an analyzer publishing
+     a `progress_features` event, (b) `StrategyLearned` consuming it with
+     a hand-set linear policy (sanity baseline), (c) ES meta-training
+     script writing the trained weights as a versioned artifact, (d) the
+     trained policy enters the nightly battery as one more spec —
+     measured, not trusted.  Item 6's diagnostics are the natural feature
+     source, so build 6 first.
+
+   Literature anchors: Dynamic Algorithm Configuration (Biedenkapp et al.,
+   2020+), adaptive operator selection, learning-to-optimize; Nevergrad's
+   NGOpt is a hand-crafted (non-learned) version of the same switching
+   idea.
+
+References: MA-BBOB generator (Vermetten et al., ACM TELO 2024);
+IOHprofiler competitions (iohprofiler.github.io/competitions); LLaMEA
+(arXiv:2405.20132); CEC winners longitudinal analysis (arXiv:2603.24140);
+benchmarking best practice (arXiv:2007.03488).
+
+## 6. Done criteria (revisit quarterly)
+
+The goal is met for a given quarter when:
+
+* mean AOCC of the best spec on the **standard** IOH battery improves
+  quarter-over-quarter with a bootstrap CI excluding zero, and
+* the best spec beats `Baseline_SciPyDE` and `Baseline_SciPyAnneal` on the
+  same battery, and
+* hold-out drift is non-negative (no overfit verdicts), and
+* every shipped change is traceable to ledger or A/B evidence.

--- a/planning/SELF_IMPROVEMENT_LOG.md
+++ b/planning/SELF_IMPROVEMENT_LOG.md
@@ -17,6 +17,85 @@ Conventions:
 * Graduate items from "Next iteration ideas" to a dated entry when
   shipped.
 
+### 2026-07-30 (second session) — Codify queue worked through: drop `Sobol` accepted; add `LBFGSB` / drop `Center` rejected (interaction negatives); structural-add driver hardened
+
+* **What** — Sequential processing of the four queued aocc codify
+  candidates, each verified with a paired A/B on the *current* spec
+  before landing (the ledger evidence for later queue entries was
+  collected against earlier spec states, so interactions must be
+  re-checked after every landing):
+
+  1. **`drop_heuristic Sobol` — ACCEPTED.**  3 confirmed nights
+     (07-13/27/29, pooled CI95% `[+0.0075, +0.0175]`), each measured on
+     that night's ladder *after* the drop-Restart accept, so the
+     evidence baseline matches the current spec.  Standard-battery A/B:
+     `Rewarding_Restart` mean AOCC `0.3342 → 0.3518` (+0.0176; d2
+     +0.0253, d5 +0.0099); the spec now beats the random floor at both
+     dims (d5 was *behind* pure random before: 0.2981 vs 0.3124).
+     Note: the 3-fixed-instance quick battery said the opposite
+     (−0.009 over 3 seeds) — overruled by the standard battery + the
+     randomized ledger nights.  Quick-battery instance sensitivity is
+     now a documented hazard for accept/reject calls.
+  2. **`add_heuristic LBFGSB({"warm_start": True})` — REJECTED**
+     (negative result).  2 nights of evidence on `Rewarding_Restart`
+     predate the Sobol drop.  On the leaner spec: standard battery
+     `0.3518 → 0.3372` (−0.0146, consistent at both dims), control
+     flat.  Interpretation: numerical-gradient polish (dim+1 evals per
+     L-BFGS-B step) costs more anytime-AOCC than it recovers now that
+     `NelderMead` is the sole local refiner on a smaller portfolio.
+     Mirrors the 2026-07-06 cold-LBFGSB composite negative.
+  3. **`drop_heuristic Center` — REJECTED** (negative result).  2
+     nights of evidence predate the Sobol drop.  Standard battery
+     `0.3518 → 0.3289` (−0.0229); d5 falls back below random (0.2769
+     vs 0.2904).  With Sobol's 32-point sweep gone, `Center`'s single
+     deterministic box-centre evaluation is a load-bearing cheap
+     prior, not dead weight.
+  4. **`Sobol.n 32 → 38` — MOOT** (the seeder it tunes was dropped).
+
+* **Driver hardening (shipped in the same session)** — the first real
+  structural *add* through `codify-scan --apply-top` exposed three
+  defects, all fixed with 8 new tests
+  (`TestStructuralAddDriverFixes`):
+
+  * **Missing-comma bug**: inserting into a compact single-line bucket
+    (`heuristics=[(Random, {})]`) produced the call expression
+    `(Random, {})(LBFGSB, {})` — syntactically parseable, crashes at
+    import.  The insertion now supplies the comma itself.
+  * **`structural_kwargs` dropped**: the edit wrote `(LBFGSB, {})`
+    where every contributing arm measured
+    `LBFGSB({"warm_start": True})` — shipping the *cold* variant the
+    2026-07-06 negative result already ruled out.
+    `CodifyCandidate` now carries `structural_kwargs_list` +
+    `consensus_structural_kwargs()` (majority, ties → most recent) and
+    the scanner renders them project-style.
+  * **No import management**: the added class was never bound in the
+    factory (→ `NameError` at first use).  `add_*` edits now also
+    rewrite the factory's `from panobbgo.heuristics import ...` /
+    `.analyzers` statement with the class inserted in sorted position
+    (one import edit per factory; skipped when already bound).
+  * **Parse-validation net**: `apply_codify_edits` refuses to write
+    any `.py` result that does not `ast.parse`, so a future primitive
+    bug surfaces as a loud skip instead of a corrupted registry.
+
+* **Guard-rail judgement call** — the LBFGSB candidate's
+  `strategy_names` included `RoundRobin_Random` (1 night); the edit
+  was *not* applied there even while testing: that spec is the pure-
+  random reference (GOAL.md §1 criterion 1 and every local A/B's
+  control).  Mutating the measuring stick invalidates the measurements.
+  Consider a codify-scan exclusion list for reference specs.
+
+* **Net effect on the metric of record** — standard battery
+  `Rewarding_Restart`: session start `0.3342` → session end `0.3518`
+  (+0.0176 from the Sobol drop; the two rejected candidates would have
+  given back −0.015/−0.023 of it had they shipped unverified).
+
+* **Next** — the queue is empty; the nightly loop now mutates a
+  3-heuristic spec (`Random` / `Nearby` / `NelderMead`) + `Sensitivity`
+  analyzer.  Fresh evidence will key on the new baseline.  Top research
+  target remains the hold-out instance-family gap (GOAL.md §5.1);
+  d5 remains barely above the random floor (0.3080 vs 0.3039) —
+  GOAL.md §5.2 (CMA-ES arm) is the natural attack.
+
 ### 2026-07-30 — Metric-aware codify routing + first aocc codify (drop `Restart` from `Rewarding_Restart`) + goal contract
 
 * **What** — Three coupled ships that un-stall the aocc-era codify last

--- a/planning/SELF_IMPROVEMENT_LOG.md
+++ b/planning/SELF_IMPROVEMENT_LOG.md
@@ -17,6 +17,65 @@ Conventions:
 * Graduate items from "Next iteration ideas" to a dated entry when
   shipped.
 
+### 2026-07-30 — Metric-aware codify routing + first aocc codify (drop `Restart` from `Rewarding_Restart`) + goal contract
+
+* **What** — Three coupled ships that un-stall the aocc-era codify last
+  mile:
+
+  1. **Metric-aware codify routing.**
+     :func:`panobbgo.self_improve.default_codify_registries` and
+     :func:`panobbgo.self_improve.default_codify_apply_sources` gain a
+     `metric: str = "composite"` parameter.  `"aocc"` routes the
+     suppression predicate to
+     :func:`panobbgo.harness_ioh.make_ioh_strategies` and the
+     `--apply-top` edit driver to `panobbgo/harness_ioh.py`
+     (`_DEFAULT_APPLY_SOURCES_AOCC`); `"composite"` (default) is
+     byte-identical to the historical behaviour.
+     `scripts/self_improve.py codify-scan` threads its existing
+     `--metric` selector into both call sites.  Six new tests in
+     `TestMetricAwareCodifyRouting`.
+  2. **First aocc codify.**  Applied via the fixed driver: dropped the
+     `(Restart, {...})` analyzer from the `Rewarding_Restart` spec in
+     `make_ioh_strategies`.  Evidence: 18 confirmed `drop_analyzer`
+     accepts across **17 distinct nights** (2026-07-09 → 2026-07-30),
+     pooled CI95% `[+0.0084, +0.0147]`, every record's `ci_low > 0`.
+     Local paired A/B on the quick IOH battery: `Rewarding_Restart`
+     mean AOCC `0.3538 → 0.3922` with the untouched
+     `RoundRobin_Random` control flat (`0.3338 → 0.3339`).
+     Interpretation: under the anytime AOCC metric the
+     diverse-restart basin jumps cost more mid-budget precision than
+     they recover — the Sensitivity analyzer stays.
+  3. **Visibility + goal contract.**  The nightly workflow now also
+     regenerates and commits `planning/self_improve_codify_scan.txt`
+     (metric-aware) so the current actionable evidence is readable
+     from the repo without running anything, and `planning/GOAL.md`
+     ships as the durable goal contract for agent-driven sessions:
+     metric of record, per-session operating loop, multi-day
+     escalation ladder, SOTA-informed research backlog (MA-BBOB /
+     LLaMEA / modular-CMA-ES context, 2026-07 snapshot).
+
+* **Why** — The 2026-07-09 flip pointed the nightly loop at the IOH
+  registry, but every codify-pipeline default still pointed at the
+  composite factories in `panobbgo/harness.py`.  Result: three weeks
+  of flat seed scores (~0.33) while the bandit re-discovered,
+  re-confirmed, and re-forgot the same improvements every night —
+  `codify-scan --apply-top` scanned the wrong file, found no matching
+  spec, and silently no-oped.  The suppression predicate was equally
+  wrong-registried, which both hid a live candidate
+  (`add_heuristic LBFGSB`, 3 nights — surfaced by the fix) and
+  mis-annotated others.
+
+* **Measured impact** — quick IOH battery mean AOCC `0.3438 → 0.3631`
+  (+0.0193); competition-candidate spec `+0.0384`.  Consistent with
+  the ledger's per-night mean Δ of `+0.0113` on the same op.
+
+* **Next** — the codify queue behind this one (in evidence order):
+  `drop_heuristic Sobol` (3 nights), `add_heuristic LBFGSB`
+  (3 nights), `drop_heuristic Center` (2 nights), `Sobol.n 32 → 38`
+  (2 nights, only meaningful if Sobol survives).  One slot per PR;
+  re-measure after each since the drops interact.  See
+  `planning/GOAL.md` §4 for the standing protocol.
+
 ### 2026-07-13 — Opt-in higher-dimensional battery: `extra_families` / `--extra-highdim` (first layer of "the measured battery is 2-D-only")
 
 * **What** — The default randomized battery

--- a/planning/self_improve_codify_scan.txt
+++ b/planning/self_improve_codify_scan.txt
@@ -1,0 +1,43 @@
+Codify scan (live=planning/self_improve_ledger_aocc.jsonl  archives=<ledger parent>/done)
+  gates: min_nights>=2, all_record_ci_low>0, hide_already_codified
+  records scanned: 613
+  candidates surfaced: 4 (of 6; 2 already codified, hidden)
+
+- Sobol [structural op=drop_heuristic] direction=drop_heuristic
+    n_accepts=3  n_nights=3  mean_Δ=+0.0125  pooled_CI95%=[+0.0075,+0.0175]  min_record_ci_low=+0.0075  confirmed=3/3
+    nights: 2026-07-13, 2026-07-27, 2026-07-29
+    live seed value(s): 'Rewarding_Restart'
+    strategies: Rewarding_Restart
+    evidence:
+      2026-07-13 06:15:16  Δ=+0.0125  CI=[+0.0125,+0.0125]  Rewarding_Restart/Sobol.: None -> None  [confirmed]
+      2026-07-27 06:26:03  Δ=+0.0075  CI=[+0.0075,+0.0075]  Rewarding_Restart/Sobol.: None -> None  [confirmed]
+      2026-07-29 05:48:18  Δ=+0.0175  CI=[+0.0175,+0.0175]  Rewarding_Restart/Sobol.: None -> None  [confirmed]
+
+- LBFGSB [structural op=add_heuristic] direction=add_heuristic
+    n_accepts=3  n_nights=3  mean_Δ=+0.0078  pooled_CI95%=[+0.0042,+0.0117]  min_record_ci_low=+0.0042  confirmed=3/3
+    nights: 2026-07-18, 2026-07-21, 2026-07-25
+    strategies: Rewarding_Restart, RoundRobin_Random
+    evidence:
+      2026-07-18 05:24:06  Δ=+0.0042  CI=[+0.0042,+0.0042]  Rewarding_Restart/LBFGSB.: None -> None  [confirmed]
+      2026-07-21 05:48:58  Δ=+0.0117  CI=[+0.0117,+0.0117]  Rewarding_Restart/LBFGSB.: None -> None  [confirmed]
+      2026-07-25 05:42:19  Δ=+0.0075  CI=[+0.0075,+0.0075]  RoundRobin_Random/LBFGSB.: None -> None  [confirmed]
+
+- Center [structural op=drop_heuristic] direction=drop_heuristic
+    n_accepts=2  n_nights=2  mean_Δ=+0.0142  pooled_CI95%=[+0.0100,+0.0183]  min_record_ci_low=+0.0100  confirmed=2/2
+    nights: 2026-07-16, 2026-07-24
+    live seed value(s): 'Rewarding_Restart'
+    strategies: Rewarding_Restart
+    evidence:
+      2026-07-16 05:37:36  Δ=+0.0183  CI=[+0.0183,+0.0183]  Rewarding_Restart/Center.: None -> None  [confirmed]
+      2026-07-24 05:46:04  Δ=+0.0100  CI=[+0.0100,+0.0100]  Rewarding_Restart/Center.: None -> None  [confirmed]
+
+- Sobol.n [integer_add] direction=up
+    n_accepts=2  n_nights=2  mean_Δ=+0.0117  pooled_CI95%=[+0.0117,+0.0117]  min_record_ci_low=+0.0117  confirmed=2/2
+    nights: 2026-07-13, 2026-07-27
+    live seed value(s): 32
+    proposed codify value: 38
+    strategies: Rewarding_Restart
+    evidence:
+      2026-07-13 06:11:41  Δ=+0.0117  CI=[+0.0117,+0.0117]  Rewarding_Restart/Sobol.n: 32 -> 40  [confirmed]
+      2026-07-27 06:25:23  Δ=+0.0117  CI=[+0.0117,+0.0117]  Rewarding_Restart/Sobol.n: 32 -> 36  [confirmed]
+

--- a/planning/self_improve_codify_scan.txt
+++ b/planning/self_improve_codify_scan.txt
@@ -1,17 +1,7 @@
 Codify scan (live=planning/self_improve_ledger_aocc.jsonl  archives=<ledger parent>/done)
   gates: min_nights>=2, all_record_ci_low>0, hide_already_codified
   records scanned: 613
-  candidates surfaced: 4 (of 6; 2 already codified, hidden)
-
-- Sobol [structural op=drop_heuristic] direction=drop_heuristic
-    n_accepts=3  n_nights=3  mean_Δ=+0.0125  pooled_CI95%=[+0.0075,+0.0175]  min_record_ci_low=+0.0075  confirmed=3/3
-    nights: 2026-07-13, 2026-07-27, 2026-07-29
-    live seed value(s): 'Rewarding_Restart'
-    strategies: Rewarding_Restart
-    evidence:
-      2026-07-13 06:15:16  Δ=+0.0125  CI=[+0.0125,+0.0125]  Rewarding_Restart/Sobol.: None -> None  [confirmed]
-      2026-07-27 06:26:03  Δ=+0.0075  CI=[+0.0075,+0.0075]  Rewarding_Restart/Sobol.: None -> None  [confirmed]
-      2026-07-29 05:48:18  Δ=+0.0175  CI=[+0.0175,+0.0175]  Rewarding_Restart/Sobol.: None -> None  [confirmed]
+  candidates surfaced: 3 (of 6; 3 already codified, hidden)
 
 - LBFGSB [structural op=add_heuristic] direction=add_heuristic
     n_accepts=3  n_nights=3  mean_Δ=+0.0078  pooled_CI95%=[+0.0042,+0.0117]  min_record_ci_low=+0.0042  confirmed=3/3
@@ -34,7 +24,6 @@ Codify scan (live=planning/self_improve_ledger_aocc.jsonl  archives=<ledger pare
 - Sobol.n [integer_add] direction=up
     n_accepts=2  n_nights=2  mean_Δ=+0.0117  pooled_CI95%=[+0.0117,+0.0117]  min_record_ci_low=+0.0117  confirmed=2/2
     nights: 2026-07-13, 2026-07-27
-    live seed value(s): 32
     proposed codify value: 38
     strategies: Rewarding_Restart
     evidence:

--- a/scripts/self_improve.py
+++ b/scripts/self_improve.py
@@ -1866,6 +1866,8 @@ def _cmd_codify_scan(args: argparse.Namespace) -> int:
     from panobbgo.self_improve import (
         aggregate_codify_candidates,
         annotate_codified_status,
+        default_codify_apply_sources,
+        default_codify_registries,
         detect_widening_candidates,
         ledger_path_for_metric,
         load_ledgers_for_codify_scan,
@@ -1904,9 +1906,11 @@ def _cmd_codify_scan(args: argparse.Namespace) -> int:
     )
 
     # Annotate already-codified status against the live seed-spec
-    # factories (quick + loop registries) so the report can suppress
-    # candidates whose implied source edit would be a no-op.
-    annotate_codified_status(candidates)
+    # factories of the selected metric's regime (composite → quick +
+    # loop registries; aocc → make_ioh_strategies) so the report can
+    # suppress candidates whose implied source edit would be a no-op.
+    metric = str(getattr(args, "metric", "composite") or "composite")
+    annotate_codified_status(candidates, registries=default_codify_registries(metric=metric))
 
     n_total_candidates = len(candidates)
     suppress_codified = getattr(args, "suppress_codified", True)
@@ -2033,6 +2037,7 @@ def _cmd_codify_scan(args: argparse.Namespace) -> int:
         rc = _apply_top_codify_candidate(
             visible_candidates,
             all_candidates=candidates,
+            sources=default_codify_apply_sources(metric=metric),
             dry_run=bool(getattr(args, "apply_dry_run", False)),
             include_bidirectional=bool(getattr(args, "apply_include_bidirectional", False)),
             open_pr=open_pr,
@@ -2052,6 +2057,7 @@ def _apply_top_codify_candidate(
     visible_candidates: Sequence[Any],
     *,
     all_candidates: Sequence[Any],
+    sources: Optional[Sequence[Tuple[str, Sequence[str]]]] = None,
     dry_run: bool,
     include_bidirectional: bool = False,
     open_pr: bool = False,
@@ -2161,7 +2167,7 @@ def _apply_top_codify_candidate(
         print(f"  selected: {slot} [{chosen.rule_kind}] direction={chosen.direction}")
         print(f"  proposed codify value: {proposed!r}")
 
-    edits, modified_files = apply_codify_candidate(chosen, dry_run=dry_run)
+    edits, modified_files = apply_codify_candidate(chosen, sources=sources, dry_run=dry_run)
     if not edits:
         if chosen.op is not None:
             print(

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -11597,7 +11597,7 @@ class TestApplyTopCLI:
         monkeypatch.setattr(
             si,
             "default_codify_apply_sources",
-            lambda: [(str(src), ("_make_quick_strategies", "_make_standard_strategies"))],
+            lambda metric="composite": [(str(src), ("_make_quick_strategies", "_make_standard_strategies"))],
         )
         return src
 
@@ -11882,7 +11882,7 @@ def _make_quick_strategies():
         monkeypatch.setattr(
             si,
             "default_codify_apply_sources",
-            lambda: [(str(src), ("_make_quick_strategies",))],
+            lambda metric="composite": [(str(src), ("_make_quick_strategies",))],
         )
         live = tmp_path / "live.jsonl"
         records = [
@@ -11945,7 +11945,7 @@ def _make_quick_strategies():
         monkeypatch.setattr(
             si,
             "default_codify_apply_sources",
-            lambda: [(str(src), ("_make_quick_strategies", "_make_standard_strategies"))],
+            lambda metric="composite": [(str(src), ("_make_quick_strategies", "_make_standard_strategies"))],
         )
         original_text = src.read_text()
         live = tmp_path / "live.jsonl"
@@ -12423,7 +12423,7 @@ class TestOpenPRCLIDriver:
         monkeypatch.setattr(
             si,
             "default_codify_apply_sources",
-            lambda: [(str(src), ("_make_quick_strategies", "_make_standard_strategies"))],
+            lambda metric="composite": [(str(src), ("_make_quick_strategies", "_make_standard_strategies"))],
         )
         live = tmp_path / "live.jsonl"
         live.write_text(
@@ -12488,7 +12488,7 @@ class TestApplyTopHygieneFlags:
         monkeypatch.setattr(
             si,
             "default_codify_apply_sources",
-            lambda: [(str(src), ("_make_quick_strategies", "_make_standard_strategies"))],
+            lambda metric="composite": [(str(src), ("_make_quick_strategies", "_make_standard_strategies"))],
         )
         live = tmp_path / "live.jsonl"
         live.write_text(
@@ -12647,7 +12647,7 @@ class TestApplyTopHygieneFlags:
         monkeypatch.setattr(
             si,
             "default_codify_apply_sources",
-            lambda: [(str(src), ("_make_quick_strategies", "_make_standard_strategies"))],
+            lambda metric="composite": [(str(src), ("_make_quick_strategies", "_make_standard_strategies"))],
         )
         live = tmp_path / "live.jsonl"
         live.write_text(
@@ -12780,3 +12780,66 @@ class TestStructuralCatalogDEAutoSizing:
         assert de_names <= set(seen), f"missing DE candidates: {de_names - set(seen)}"
         for name, np_init in seen.items():
             assert np_init == "auto", f"{name} should size NP_init automatically, got {np_init!r}"
+
+
+class TestMetricAwareCodifyRouting:
+    """The codify pipeline routes registries / apply sources by metric.
+
+    Since the 2026-07-09 nightly flip to ``--metric aocc``, the loop
+    measures :func:`panobbgo.harness_ioh.make_ioh_strategies` — not the
+    composite quick / loop registries.  Both the suppression predicate
+    (:func:`default_codify_registries`) and the ``--apply-top`` edit
+    driver (:func:`default_codify_apply_sources`) must follow the
+    metric, otherwise aocc evidence can never land as a source edit
+    (the driver scans ``harness.py``, finds no matching spec, and
+    silently no-ops — the failure mode that stalled codification
+    between 2026-07-09 and 2026-07-30).
+    """
+
+    def test_default_registries_composite_unchanged(self):
+        from panobbgo.harness import _make_loop_strategies, _make_quick_strategies
+        from panobbgo.self_improve import default_codify_registries
+
+        assert default_codify_registries() == default_codify_registries(metric="composite")
+        factories = default_codify_registries(metric="composite")
+        assert _make_quick_strategies in factories
+        assert _make_loop_strategies in factories
+
+    def test_default_registries_aocc_is_ioh(self):
+        from panobbgo.harness_ioh import make_ioh_strategies
+        from panobbgo.self_improve import default_codify_registries
+
+        assert default_codify_registries(metric="aocc") == [make_ioh_strategies]
+
+    def test_default_apply_sources_composite_unchanged(self):
+        from panobbgo.self_improve import default_codify_apply_sources
+
+        assert default_codify_apply_sources() == default_codify_apply_sources(metric="composite")
+        paths = [path for path, _names in default_codify_apply_sources(metric="composite")]
+        assert paths == ["panobbgo/harness.py"]
+
+    def test_default_apply_sources_aocc_is_harness_ioh(self):
+        from panobbgo.self_improve import default_codify_apply_sources
+
+        sources = default_codify_apply_sources(metric="aocc")
+        assert sources == [("panobbgo/harness_ioh.py", ("make_ioh_strategies",))]
+
+    def test_apply_sources_returns_fresh_list_per_metric(self):
+        from panobbgo.self_improve import default_codify_apply_sources
+
+        first = default_codify_apply_sources(metric="aocc")
+        first.append(("bogus.py", ("nope",)))
+        assert default_codify_apply_sources(metric="aocc") == [("panobbgo/harness_ioh.py", ("make_ioh_strategies",))]
+
+    def test_ioh_registry_factories_are_callable_specs(self):
+        # The suppression predicate walks factory() output — make sure the
+        # aocc factory actually yields StrategySpec objects with the
+        # buckets the structural membership check reads.
+        from panobbgo.self_improve import default_codify_registries
+
+        (factory,) = default_codify_registries(metric="aocc")
+        specs = factory()
+        assert len(specs) >= 2
+        for spec in specs:
+            assert hasattr(spec, "heuristics")
+            assert hasattr(spec, "analyzers")

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -12843,3 +12843,186 @@ class TestMetricAwareCodifyRouting:
         for spec in specs:
             assert hasattr(spec, "heuristics")
             assert hasattr(spec, "analyzers")
+
+
+class TestStructuralAddDriverFixes:
+    """2026-07-30 fixes to the structural ``add_*`` edit primitive.
+
+    Three defects surfaced when the first real aocc structural add
+    (``LBFGSB`` onto the IOH registry) ran through the driver: a
+    missing comma after compact single-line buckets produced a *call
+    expression* ``(Random, {})(LBFGSB, {})``; the measured arm's
+    ``structural_kwargs`` were dropped (shipping cold LBFGSB where the
+    ledger measured ``warm_start=True``); and the added class was never
+    imported by the factory.  ``apply_codify_edits`` additionally
+    gained a parse-validation net so a broken edit can never land.
+    """
+
+    def _write_factory(self, tmp_path, body):
+        src = tmp_path / "fake_registry.py"
+        src.write_text(body)
+        return src
+
+    def _candidate(self, *, strategy_names=("Spec_A",), kwargs_list=()):
+        from panobbgo.self_improve import CodifyCandidate
+
+        return CodifyCandidate(
+            class_name="LBFGSB",
+            param_name="",
+            rule_kind="structural",
+            op="add_heuristic",
+            direction="add_heuristic",
+            n_accepts=max(1, len(strategy_names)),
+            distinct_dates=("2026-07-18", "2026-07-21"),
+            deltas=(0.01,) * max(1, len(strategy_names)),
+            ci_lows=(0.005,) * max(1, len(strategy_names)),
+            ci_highs=(0.02,) * max(1, len(strategy_names)),
+            old_values=(None,) * max(1, len(strategy_names)),
+            new_values=(None,) * max(1, len(strategy_names)),
+            timestamps=("t",) * max(1, len(strategy_names)),
+            strategy_names=tuple(strategy_names),
+            confirmed_flags=(True,) * max(1, len(strategy_names)),
+            structural_kwargs_list=tuple(kwargs_list),
+        )
+
+    _SINGLE_LINE_FACTORY = (
+        "from panobbgo.benchmark import StrategySpec\n"
+        "\n"
+        "\n"
+        "def make_fake_specs():\n"
+        "    from panobbgo.heuristics import Random\n"
+        "\n"
+        "    return [\n"
+        "        StrategySpec(\n"
+        '            name="Spec_A",\n'
+        "            strategy_class=None,\n"
+        "            heuristics=[(Random, {})],\n"
+        "        ),\n"
+        "    ]\n"
+    )
+
+    def test_single_line_bucket_add_stays_syntactically_valid(self, tmp_path):
+        import ast as _ast
+
+        from panobbgo.self_improve import derive_codify_edits, apply_codify_edits
+
+        src = self._write_factory(tmp_path, self._SINGLE_LINE_FACTORY)
+        cand = self._candidate(kwargs_list=({"warm_start": True},))
+        edits = derive_codify_edits(cand, sources=[(str(src), ("make_fake_specs",))])
+        entry_edits = [e for e in edits if e.spec_name == "Spec_A"]
+        assert len(entry_edits) == 1
+        new_text = apply_codify_edits(edits, dry_run=True)[str(src)]
+        _ast.parse(new_text)  # the pre-fix driver produced a call expression here
+        assert "(Random, {})," in new_text.replace("\n", " ")
+
+    def test_add_carries_consensus_structural_kwargs(self, tmp_path):
+        from panobbgo.self_improve import derive_codify_edits
+
+        src = self._write_factory(tmp_path, self._SINGLE_LINE_FACTORY)
+        cand = self._candidate(
+            kwargs_list=({"warm_start": True}, {"warm_start": True}, None),
+        )
+        edits = derive_codify_edits(cand, sources=[(str(src), ("make_fake_specs",))])
+        entry = [e for e in edits if e.spec_name == "Spec_A"][0]
+        assert '(LBFGSB, {"warm_start": True})' in entry.new_source
+
+    def test_add_without_kwargs_renders_empty_dict(self, tmp_path):
+        from panobbgo.self_improve import derive_codify_edits
+
+        src = self._write_factory(tmp_path, self._SINGLE_LINE_FACTORY)
+        cand = self._candidate(kwargs_list=(None,))
+        edits = derive_codify_edits(cand, sources=[(str(src), ("make_fake_specs",))])
+        entry = [e for e in edits if e.spec_name == "Spec_A"][0]
+        assert "(LBFGSB, {})" in entry.new_source
+
+    def test_add_rewrites_factory_import_sorted(self, tmp_path):
+        from panobbgo.self_improve import derive_codify_edits, apply_codify_edits
+
+        src = self._write_factory(tmp_path, self._SINGLE_LINE_FACTORY)
+        cand = self._candidate(kwargs_list=({"warm_start": True},))
+        edits = derive_codify_edits(cand, sources=[(str(src), ("make_fake_specs",))])
+        import_edits = [e for e in edits if e.spec_name == "<import>"]
+        assert len(import_edits) == 1
+        new_text = apply_codify_edits(edits, dry_run=True)[str(src)]
+        assert "from panobbgo.heuristics import LBFGSB, Random" in new_text
+
+    def test_add_skips_import_edit_when_already_bound(self, tmp_path):
+        from panobbgo.self_improve import derive_codify_edits
+
+        body = self._SINGLE_LINE_FACTORY.replace(
+            "from panobbgo.heuristics import Random",
+            "from panobbgo.heuristics import LBFGSB, Random",
+        )
+        src = self._write_factory(tmp_path, body)
+        cand = self._candidate(kwargs_list=({"warm_start": True},))
+        edits = derive_codify_edits(cand, sources=[(str(src), ("make_fake_specs",))])
+        assert [e for e in edits if e.spec_name == "<import>"] == []
+
+    def test_apply_refuses_to_write_broken_python(self, tmp_path):
+        from panobbgo.self_improve import CodifyEdit, apply_codify_edits
+
+        src = tmp_path / "victim.py"
+        original = "x = 1\n"
+        src.write_text(original)
+        bad_edit = CodifyEdit(
+            source_path=str(src),
+            factory_name="f",
+            spec_name="s",
+            class_name="C",
+            param_name="",
+            rule_kind="structural",
+            direction="add_heuristic",
+            old_value=None,
+            new_value=None,
+            lineno=1,
+            col_offset=5,
+            end_lineno=1,
+            end_col_offset=5,
+            old_source="",
+            new_source=")broken(",
+        )
+        out = apply_codify_edits([bad_edit], dry_run=False)
+        assert str(src) not in out
+        assert src.read_text() == original
+
+    def test_consensus_structural_kwargs_majority_and_tie(self):
+        cand = self._candidate(
+            kwargs_list=({"a": 1}, {"a": 2}, {"a": 2}),
+        )
+        assert cand.consensus_structural_kwargs() == {"a": 2}
+        tie = self._candidate(kwargs_list=({"a": 1}, {"a": 2}))
+        # Ties break toward the most recent record.
+        assert tie.consensus_structural_kwargs() == {"a": 2}
+        empty = self._candidate(kwargs_list=(None, None))
+        assert empty.consensus_structural_kwargs() is None
+
+    def test_aggregate_collects_structural_kwargs(self):
+        from panobbgo.self_improve import aggregate_codify_candidates
+
+        def rec(day, kwargs):
+            return {
+                "record_type": "iteration",
+                "accepted": True,
+                "delta": 0.01,
+                "ci_low": 0.005,
+                "ci_high": 0.02,
+                "timestamp": f"{day}T05:00:00+00:00",
+                "confirmed": True,
+                "proposal": {
+                    "strategy_name": "Spec_A",
+                    "class_name": "LBFGSB",
+                    "param_name": "",
+                    "rule_kind": "add_heuristic",
+                    "op": "add_heuristic",
+                    "old_value": None,
+                    "new_value": None,
+                    "structural_kwargs": kwargs,
+                },
+            }
+
+        cands = aggregate_codify_candidates(
+            [rec("2026-07-18", {"warm_start": True}), rec("2026-07-21", {"warm_start": True})]
+        )
+        assert len(cands) == 1
+        assert cands[0].consensus_structural_kwargs() == {"warm_start": True}
+        assert cands[0].to_dict()["structural_kwargs"] == {"warm_start": True}


### PR DESCRIPTION
## Summary

Un-stalls the self-improvement loop's codify last mile for the AOCC era, works the accumulated evidence queue end-to-end (1 accept, 2 verified rejections), hardens the structural-edit driver, and adds a durable goal contract so agent-driven sessions can run the improvement loop for days with a standing objective.

### The stall (diagnosis)

Since the 2026-07-09 nightly flip to `--metric aocc`, the loop measures the IOH registry (`panobbgo/harness_ioh.py::make_ioh_strategies`) — but every codify-pipeline default still pointed at the composite factories in `panobbgo/harness.py`:

- `default_codify_registries()` (already-codified suppression) compared candidates against specs the aocc loop never runs.
- `default_codify_apply_sources()` (the `codify-scan --apply-top` edit driver) scanned `harness.py`, found no spec named `Rewarding_Restart`, and silently no-oped.

Result: three weeks of flat seed scores (~0.33 mean AOCC) while the bandit re-discovered, re-confirmed, and re-forgot the same improvements every night — the top candidate (`drop_analyzer Restart`) accumulated **18 confirmed accepts across 17 distinct nights** without ever landing in source.

### Changes

1. **Metric-aware codify routing** — `default_codify_registries(metric=...)` and `default_codify_apply_sources(metric=...)` (`"composite"` default is byte-identical to before; `"aocc"` routes to `make_ioh_strategies` / `panobbgo/harness_ioh.py`). `codify-scan` threads its existing `--metric` selector into both call sites.
2. **Codify queue worked end-to-end** (each candidate A/B-verified on the *current* spec before landing, since ledger evidence for later entries predates earlier landings):
   - **drop `Restart` analyzer** — ACCEPTED (17 nights, pooled CI95% `[+0.0084, +0.0147]`)
   - **drop `Sobol` seeder** — ACCEPTED (3 nights; standard battery `0.3342 → 0.3518`, spec now beats the random floor at both dims — it was *behind* at d5 before)
   - **add `LBFGSB(warm_start=True)`** — REJECTED, interaction negative (−0.0146 on the post-Sobol-drop spec; evidence predates the drop)
   - **drop `Center`** — REJECTED, interaction negative (−0.0229; without Sobol, Center's box-centre eval is load-bearing)
   - **`Sobol.n 32→38`** — moot (seeder dropped)
3. **Structural-add driver hardened** (defects exposed by the first real structural add): missing-comma fix for single-line buckets (was emitting the call expression `(Random, {})(LBFGSB, {})`); `structural_kwargs` now carried into edits (the arm measured `warm_start=True` — the cold variant is a known negative); factory-import rewriting for added classes; `apply_codify_edits` refuses to write any `.py` result that fails `ast.parse`.
4. **Nightly visibility** — `self_improve_nightly.yml` now regenerates and commits `planning/self_improve_codify_scan.txt` (metric-aware) alongside the summary.
5. **Goal contract for multi-day agent runs** — new `planning/GOAL.md`: metric of record (AOCC on MA-BBOB), per-session operating loop, multi-day escalation ladder, guardrails, and a SOTA-informed research backlog (MA-BBOB competition context, LLaMEA 2024/2025 wins, modular CMA-ES / rank-stats / plain-BBOB validation, and a learned "intuition layer" / Dynamic Algorithm Configuration path with ES meta-training on the existing randomized battery). Pointers added to `AGENTS.md`; dated entries in `planning/SELF_IMPROVEMENT_LOG.md`; `TODO.md` updated.

## Evidence

Standard IOH battery (dims 2+5 × 5 instances, paired instances/seeds), `Rewarding_Restart`:

| state | mean AOCC | d=2 | d=5 |
|---|---|---|---|
| master (Restart + Sobol + Center) | 0.3342 | 0.3703 | 0.2981 (below random 0.3124) |
| **this PR** (− Restart analyzer, − Sobol) | **0.3518** | **0.3956** | **0.3080** (above random 0.3039) |

`RoundRobin_Random` control stayed flat throughout (deliberately never mutated — it is the reference floor). The two rejected candidates would have given back −0.015/−0.023 had they shipped unverified.

## Testing

- `tests/test_self_improve.py` + `tests/test_harness_ioh.py`: 637 passed (incl. 6 new `TestMetricAwareCodifyRouting` + 8 new `TestStructuralAddDriverFixes`)
- full `uv run pytest` suite green at the routing-fix commit (1892 passed, 1 skipped)
- `ruff check` / `ruff format --check` / `pyright` clean on changed files

## Follow-ups

- Queue is empty; the nightly loop now mutates the leaner 3-heuristic spec and accumulates fresh evidence on the new baseline (daily agent Routine banks it each morning).
- Top research targets per `planning/GOAL.md` §5: hold-out instance-family gap (0.04 vs 0.33), CMA-ES arm (d5 is barely above the random floor), rank-based acceptance stats.
- Consider a codify-scan exclusion list for reference specs (`RoundRobin_Random` evidence was deliberately not applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8DyRXDLjDLDzVwv1xA3pq